### PR TITLE
Fix "Do you want to reinstall" prompt for Windows.

### DIFF
--- a/cli/installer.php
+++ b/cli/installer.php
@@ -62,7 +62,7 @@ class InstallerApplication extends JApplicationCli
 
 			$this->out('WARNING: A database has been found. Do you want to reinstall ? [y]es / [n]o :', false);
 
-			$resp = $this->in();
+			$resp = trim($this->in());
 
 			if ('yes' != $resp && 'y' != $resp)
 				throw new InstallerAbortException;


### PR DESCRIPTION
The response for "Do you want to reinstall" contained an additional character (presumably a CR or LF).  I've added a trim().
