### PR TITLE
Fix Joomlacode Tracker ID parsing.

### DIFF
--- a/cli/retrieveissues.php
+++ b/cli/retrieveissues.php
@@ -183,7 +183,7 @@ class TrackerApplicationRetrieve extends JApplicationCli
 
 			// If the title has a [# in it, assume it's a Joomlacode Tracker ID
 			// TODO - Would be better suited as a regex probably
-			if (strpos($issue->title, '[#'))
+			if (strpos($issue->title, '[#') !== false)
 			{
 				$pos = strpos($issue->title, '[#') + 2;
 				$table->jc_id = substr($issue->title, $pos, 5);


### PR DESCRIPTION
strpos returns a 0 for a start of string match.  Changed the test to use "strpos(...) !== false".
