### PR TITLE
Update libraries/config.example.php

### DIFF
--- a/libraries/config.example.php
+++ b/libraries/config.example.php
@@ -1,5 +1,5 @@
 <?php
-class JConfigExample
+class JConfig
 {
 	public $dbtype			= 'mysqli';
 	public $host			= 'localhost';


### PR DESCRIPTION
Since the file is config.example.php, we really don't need the class to be named JConfigExample. Saves a step during installation.
