### PR TITLE
Add comment count to issue list

### DIFF
--- a/components/com_tracker/model/issues.php
+++ b/components/com_tracker/model/issues.php
@@ -50,6 +50,10 @@ class TrackerModelIssues extends JModelTrackerList
 		$query->select('c.title AS category');
 		$query->leftJoin('#__categories AS c ON a.catid = c.id');
 
+		// Comments count
+		$query->select('COUNT(ic.id) AS comment_count');
+		$query->leftJoin('#__issue_comments AS ic ON ic.issue_id = a.id');
+
 		$filter = $this->state->get('filter.project');
 
 		if ($filter)
@@ -73,6 +77,8 @@ class TrackerModelIssues extends JModelTrackerList
 		{
 			$query->where($db->quoteName('a.status') . ' = ' . (int) $status);
 		}
+
+		$query->group('a.id');
 
 		// TODO: Implement filtering and join to other tables as added
 

--- a/components/com_tracker/view/issues/tmpl/default.php
+++ b/components/com_tracker/view/issues/tmpl/default.php
@@ -92,6 +92,12 @@ $fields = new JRegistry(JFactory::getApplication()->input->get('fields', array()
 					<div class="hasTooltip" title="<?php echo JHtml::_('string.truncate', $this->escape($item->description), 100); ?>">
 						<a href="index.php?option=com_tracker&view=issue&id=<?php echo (int) $item->id;?>">
 						<?php echo $this->escape($item->title); ?></a>
+						<!-- Comment count -->
+						<?php if (isset($item->comment_count) && $item->comment_count > 0): ?>
+							<span class="comment_count">
+								[<?php echo $item->comment_count; ?> <?php echo JText::_('COM_TRACKER_LABEL_ISSUE_COMMENTS'); ?>]
+							</span>
+						<?php endif; ?>
 					</div>
 					<?php if ($item->gh_id || $item->jc_id) : ?>
 					<div class="small">

--- a/libraries/tracker/model/tracker/list.php
+++ b/libraries/tracker/model/tracker/list.php
@@ -297,7 +297,7 @@ abstract class JModelTrackerList extends JModelTracker
 		{
 			// Create COUNT(*) query to allow database engine to optimize the query.
 			$query = clone $query;
-			$query->clear('select')->clear('order')->clear('join')->select('COUNT(*)');
+			$query->clear('select')->clear('order')->clear('join')->clear('group')->select('COUNT(*)');
 			$this->db->setQuery($query);
 
 			return (int) $this->db->loadResult();


### PR DESCRIPTION
I wanted to add a comment counter in the issue list view.

Please review:

1.- I added the comment count after the issue title and it's only shown when there are comments. I thought about adding a column but not sure if I like that. 

Suggestions are welcome. This is how it's shown:

![test](https://f.cloud.github.com/assets/1119272/36305/22a84424-5304-11e2-86bc-0350d2a9f40f.png)

2.- I had to patch the _getListCount method in:

```
libraries/tracker/model/tracker/list.php
```

to clear the group because after adding comments count it was only returning 1.
