### PR TITLE
Quick README.md correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The issue tracker application requires a server running:
 Setup
 ===============
 1. Clone the git repo to where ever your test environment is located or download the ZIP from https://github.com/JTracker/jissues/zipball/master.
-2. Copy `/libraries/config.example.php` to `/configuration.php`
+2. Copy `/libraries/config.example.php` to `/config.php`
 3. Enter your database credentials in the `JConfig` class. Change $prefix if desired. (defaults to jos_)
 
 From this point, you can setup your database in one of two ways:


### PR DESCRIPTION
Corrected the reference to "configuration.php" to read "config.php" instead since my local install was unable to work properly and giving "no database selected" errors because it couldn't find the configuration settings.
