### PR TITLE
Add error_reporting into config example file

### DIFF
--- a/configuration.example.php
+++ b/configuration.example.php
@@ -13,6 +13,7 @@ class JConfig
 	public $password		= '';
 	public $db				= '';
 	public $dbprefix		= 'jos_';
+	public $error_reporting = 'maximum';
 	public $ftp_host		= '127.0.0.1';
 	public $ftp_port		= '21';
 	public $ftp_user		= '';


### PR DESCRIPTION
Fixes the two errors found when going into administrator backend
( ! ) Notice: Undefined property: JConfig::$error_reporting in C:\wamp\www\jissues\administrator\includes\framework.php on line 49
( ! ) Notice: Undefined property: JConfig::$error_reporting in C:\wamp\www\jissues\administrator\includes\framework.php on line 76

As its a thing in development - I guess maximum is the best for this!
