### PR TITLE
Add composer to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@
 
 # Files that should not be pushed to the repo #
 /etc/configuration.php
+
+# Apple Files #
+.DS_STORE
+
+# COMPOSER Files #
+vendor/*
+composer.phar


### PR DESCRIPTION
This pull adds:
- Git ignore for .DS_STORE apple mac files.
- ignore vendor/\* folder that will be filled by composer with Twig, composer itself and the joomla Framework.
- composer.phar. Since everyone can download composer in the folder I'm ignoring it.
