### PR TITLE
Add project short title, set standard site title, project name cleanup

### DIFF
--- a/etc/mysql.sql
+++ b/etc/mysql.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS `#__tracker_projects` (
   `gh_user` varchar(150) NOT NULL COMMENT 'GitHub user',
   `gh_project` varchar(150) NOT NULL COMMENT 'GitHub project',
   `ext_tracker_link` varchar(500) NOT NULL COMMENT 'A tracker link format (e.g. http://tracker.com/issue/%d)',
+	`short_title` varchar(50) NOT NULL COMMENT 'Project short title',
   PRIMARY KEY (`project_id`),
   KEY `alias` (`alias`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -33,10 +34,10 @@ CREATE TABLE IF NOT EXISTS `#__tracker_projects` (
 -- Dumping data `#__tracker_projects`
 --
 
-INSERT INTO `#__tracker_projects` (`project_id`, `title`, `alias`, `gh_user`, `gh_project`, `ext_tracker_link`) VALUES
-(1, 'Joomla! CMS 3 issues', 'joomla-cms-3-issues', 'joomla', 'joomla-cms', 'http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=%d'),
-(2, 'J!Tracker Bugs', 'jtracker-bugs', 'joomla', 'jissues', ''),
-(3, 'Joomla! Security', 'joomla-security', '', '', '');
+INSERT INTO `#__tracker_projects` (`project_id`, `title`, `alias`, `gh_user`, `gh_project`, `ext_tracker_link`, `short_title`) VALUES
+(1, 'Joomla! CMS', 'joomla-cms', 'joomla', 'joomla-cms', 'http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=%d', 'CMS'),
+(2, 'J!Tracker', 'jtracker', 'joomla', 'jissues', '', 'J!Tracker'),
+(3, 'Joomla! Security', 'joomla-security', '', '', '', 'JSST');
 
 -- --------------------------------------------------------
 

--- a/src/App/Projects/Table/ProjectsTable.php
+++ b/src/App/Projects/Table/ProjectsTable.php
@@ -23,6 +23,7 @@ use JTracker\Database\AbstractDatabaseTable;
  * @property   string   $gh_user           GitHub user
  * @property   string   $gh_project        GitHub project
  * @property   string   $ext_tracker_link  A tracker link format (e.g. http://tracker.com/issue/%d)
+ * @property   string   $short_title       Project short title
  *
  * @since  1.0
  */
@@ -54,6 +55,11 @@ class ProjectsTable extends AbstractDatabaseTable
 		if (!$this->title)
 		{
 			throw new \UnexpectedValueException(g11n3t('A title is required'));
+		}
+
+		if (!$this->short_title)
+		{
+			throw new \UnexpectedValueException(g11n3t('A short title is required'));
 		}
 
 		if (!$this->alias)

--- a/src/App/Projects/TrackerProject.php
+++ b/src/App/Projects/TrackerProject.php
@@ -67,6 +67,14 @@ class TrackerProject
 	protected $ext_tracker_link;
 
 	/**
+	 * Project short title
+	 *
+	 * @var    string
+	 * @since  1.0
+	 */
+	protected $short_title;
+
+	/**
 	 * Access map
 	 *
 	 * @var    array
@@ -370,5 +378,17 @@ class TrackerProject
 	public function getExt_Tracker_Link()
 	{
 		return $this->ext_tracker_link;
+	}
+
+	/**
+	 * Get the project short title.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getShort_Title()
+	{
+		return $this->short_title;
 	}
 }

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -39,7 +39,7 @@
             <div class="row-fluid">
                 {% block header %}
                     <div class="span7">
-                        <h1 class="page-title">{% block headerText %}Joomla! Tracker{% endblock %}</h1>
+                        <h1 class="page-title">Joomla! Issue Tracker{% block headerText %}{% endblock %}</h1>
                     </div>
                     <div class="span5">
                         <div class="btn-toolbar pull-right">

--- a/templates/projects/project.add.twig
+++ b/templates/projects/project.add.twig
@@ -30,6 +30,11 @@
                 </li>
 
                 <li>
+                    <label for="short_title">{{ "Short Title"|_ }}</label>
+                    <input type="text" name="project[short_title]" id="short_title" />
+                </li>
+
+                <li>
                     <label for="alias">{{ "Alias"|_ }}</label>
                     <input type="text" name="project[alias]" id="alias" />
                 </li>

--- a/templates/projects/project.edit.twig
+++ b/templates/projects/project.edit.twig
@@ -41,6 +41,13 @@
             </div>
 
             <div class="control-group">
+                <label class="control-label" for="short_title">{{ "Short Title"|_ }}</label>
+                <div class="controls">
+                    <input type="text" name="project[short_title]" id="short_title" value="{{ project.short_title }}">
+                </div>
+            </div>
+
+            <div class="control-group">
                 <label class="control-label" for="alias">{{ "Alias"|_ }}</label>
                 <div class="controls">
                     <input type="text" name="project[alias]" id="alias" value="{{ project.alias }}">

--- a/templates/tracker/issues.index.twig
+++ b/templates/tracker/issues.index.twig
@@ -5,7 +5,7 @@
 
 {% block title %}Issues List{% endblock %}
 
-{% block headerText %}{{ project.title }}{% endblock %}
+{% block headerText %} - {{ project.short_title }}{% endblock %}
 
 {% block headerCSS %}
     <link href="{{ uri.base.path }}jtracker/pagination/css/pagination.css" rel="stylesheet" media="screen">


### PR DESCRIPTION
In another move aimed for better consistency across the j.org network, I've reworked the main title displayed in the page header some.  It will now always show as "Joomla! Issue Tracker" with the ability to append to it, used for the tracker pages.  To keep the title from running too long, I've added a `short_title` field for the projects table and use that to display a unique appendix for the trackers.  So now we display "Joomla! Issue Tracker - CMS" instead.

Point 2 with this is cleanup of the project names and aliases, ultimately aimed for a better experience.  "Joomla! CMS 3 Issues" is shortened to just "Joomla! CMS" and its alias shortened the same.
