### PR TITLE
Add a lookup for alternatives on CNF - Did you mean one of this?

### DIFF
--- a/cli/CliApp/Application/CliApplication.php
+++ b/cli/CliApp/Application/CliApplication.php
@@ -8,6 +8,7 @@
 
 namespace CliApp\Application;
 
+use CliApp\Command\Help\Help;
 use CliApp\Command\TrackerCommandOption;
 use CliApp\Exception\AbortException;
 use CliApp\Service\GitHubProvider;
@@ -178,8 +179,18 @@ class CliApplication extends AbstractCliApplication
 		if (false == class_exists($className))
 		{
 			$this->out()
-				->out('<error>Invalid command</error>: ' . (($command == $action) ? $command : $command . ' ' . $action))
+				->out('Invalid command: <error> ' . (($command == $action) ? $command : $command . ' ' . $action) . ' </error>')
 				->out();
+
+			$alternatives = $this->getAlternatives($command, $action);
+
+			if (count($alternatives))
+			{
+				$this->out('<b>Did you mean one of this?</b>')
+					->out('    <question> ' . implode(' </question>    <question> ', $alternatives) . ' </question>');
+
+				return;
+			}
 
 			$className = 'CliApp\\Command\\Help\\Help';
 		}
@@ -208,6 +219,49 @@ class CliApplication extends AbstractCliApplication
 				)
 			)
 			->out(str_repeat('_', 40));
+	}
+
+	/**
+	 * Get alternatives for a not found command or action.
+	 *
+	 * @param   string  $command  The command.
+	 * @param   string  $action   The action.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	protected function getAlternatives($command, $action)
+	{
+		$commands = with(new Help)->getCommands();
+		$alternatives = array();
+
+		if (false == array_key_exists($command, $commands))
+		{
+			// Unknown command
+			foreach (array_keys($commands) as $cmd)
+			{
+				if (levenshtein($cmd, $command) <= strlen($cmd) / 3 || false !== strpos($cmd, $command))
+				{
+					$alternatives[] = $cmd;
+				}
+			}
+		}
+		else
+		{
+			// Known command - unknown action
+			$actions = with(new Help)->getActions($command);
+
+			foreach (array_keys($actions) as $act)
+			{
+				if (levenshtein($act, $action) <= strlen($act) / 3 || false !== strpos($act, $action))
+				{
+					$alternatives[] = $command . ' ' . $act;
+				}
+			}
+		}
+
+		return $alternatives;
 	}
 
 	/**

--- a/cli/CliApp/Command/Help/Help.php
+++ b/cli/CliApp/Command/Help/Help.php
@@ -117,7 +117,7 @@ class Help extends TrackerCommand
 		if (false == array_key_exists($command, $this->commands))
 		{
 			$this->out()
-				->out('Unknown command: ' . $command);
+				->out('Unknown: ' . $command);
 
 			return;
 		}
@@ -194,7 +194,7 @@ class Help extends TrackerCommand
 	 *
 	 * @since   1.0
 	 */
-	private function getCommands()
+	public function getCommands()
 	{
 		$commands = array();
 
@@ -225,7 +225,7 @@ class Help extends TrackerCommand
 	 *
 	 * @since   1.0
 	 */
-	protected function getActions($commandName)
+	public function getActions($commandName)
 	{
 		$actions = array();
 		$cName = ucfirst($commandName);

--- a/cli/CliApp/Command/Make/Autocomplete.php
+++ b/cli/CliApp/Command/Make/Autocomplete.php
@@ -8,6 +8,7 @@
 
 namespace CliApp\Command\Make;
 
+use CliApp\Command\Help\Help;
 use CliApp\Command\TrackerCommand;
 
 /**
@@ -38,7 +39,7 @@ class Autocomplete extends Make
 
 		$cliBase = JPATH_ROOT . '/cli/CliApp/Command';
 
-		$helper = new Helper($this->application);
+		$helper = new Help;
 
 		$xml = simplexml_load_string(
 			'<framework xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
@@ -66,8 +67,7 @@ class Autocomplete extends Make
 				/* @type TrackerCommand $class */
 				$class = new $className($this->application);
 
-				$help = $class->getDescription();
-				$help = str_replace(array('<cmd>', '</cmd>', '<', '>'), '', $help);
+				$help = str_replace(array('<cmd>', '</cmd>', '<', '>'), '', $class->getDescription());
 
 				$xmlCommand = $xml->addChild('command');
 
@@ -84,7 +84,7 @@ class Autocomplete extends Make
 				/* @type TrackerCommand $option */
 				foreach ($actions as $name => $option)
 				{
-					$help = $option->getDescription();
+					$help = str_replace(array('<cmd>', '</cmd>', '<', '>'), '', $option->getDescription());
 
 					$xmlCommand = $xml->addChild('command');
 					$xmlCommand->addChild('name', strtolower($command) . ' ' . strtolower($name));
@@ -105,29 +105,5 @@ class Autocomplete extends Make
 
 		$this->out()
 			->out('Finished =;)');
-	}
-}
-
-/**
- * Class Helper.
- *
- * Dummy class to expose a protected method.
- *
- * @since  1.0
- */
-class Helper extends \CliApp\Command\Help\Help
-{
-	/**
-	 * Get available actions for a command.
-	 *
-	 * @param   string  $commandName  The command name.
-	 *
-	 * @return  array
-	 *
-	 * @since   1.0
-	 */
-	public function getActions($commandName)
-	{
-		return parent::getActions($commandName);
 	}
 }


### PR DESCRIPTION
This will add a lookup for alternatives if a command or an action is not found.
![cnf-lookup](https://f.cloud.github.com/assets/33978/1646707/9ea4a67c-5924-11e3-9cc3-b2c097096fda.png)
![cnf-lookup1](https://f.cloud.github.com/assets/33978/1646708/9eb877a6-5924-11e3-96e9-82cc4cc0db59.png)

Note: This has been inspired by https://github.com/joomla/joomla-framework/pull/275 and https://github.com/symfony/symfony/blob/db4f5515272874eac36fb46a9d45737c2a1319ef/src/Symfony/Component/Console/Application.php#L1048-1089
