### PR TITLE
Add `get composertags` command

### DIFF
--- a/cli/CliApp/Command/Get/Composertags.php
+++ b/cli/CliApp/Command/Get/Composertags.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Part of the Joomla! Tracker application.
+ *
+ * @copyright  Copyright (C) 2012 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CliApp\Command\Get;
+
+use CliApp\Command\Make\Depfile;
+use CliApp\Command\TrackerCommandOption;
+
+use JTracker\Container;
+
+/**
+ * Class for retrieving repository tags from GitHub based on the composer file.
+ *
+ * @since  1.0
+ */
+class Composertags extends Get
+{
+	/**
+	 * The command "description" used for help texts.
+	 *
+	 * @var    string
+	 * @since  1.0
+	 */
+	protected $description = 'Retrieve a list of project tags from GitHub and show their installed versions.';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since   1.0
+	 */
+	public function __construct()
+	{
+		$this->application = Container::retrieve('app');
+		$this->logger      = Container::retrieve('logger');
+
+		$this
+			->addOption(
+				new TrackerCommandOption(
+					'all', '',
+					'Show all tags or only the most recent.'
+				)
+			);
+	}
+
+	/**
+	 * Execute the command.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function execute()
+	{
+		$this->application->outputTitle('Retrieve composer tags');
+
+		$packages = with(new Depfile)->getComposerInstalled();
+		$allTags  = $this->application->input->get('all');
+
+		$this->logOut('Start getting composer tags.')
+			->setupGitHub()
+			->displayGitHubRateLimit()
+			->fetchTags($packages, $allTags)
+			->out()
+			->logOut('Finished.');
+	}
+
+	/**
+	 * Fetch Tags.
+	 *
+	 * @param   array    $packages  List of installed packages
+	 * @param   boolean  $allTags   Fetch all tags or only the "most recent".
+	 *
+	 * @return  $this
+	 *
+	 * @since   1.0
+	 */
+	private function fetchTags(array $packages, $allTags = false)
+	{
+		foreach ($packages as $package)
+		{
+			$this->out($package->name);
+
+			if (!preg_match('|https://github.com/([A-z0-9\-]+)/([A-z0-9\-\.]+).git|', $package->sourceURL, $matches))
+			{
+				$this->out('CAN NOT PARSE: ' . $package->sourceURL);
+
+				continue;
+			}
+
+			$owner = $matches[1];
+			$repo  = $matches[2];
+
+			$tags = $this->github->repositories->getListTags($owner, $repo);
+
+			$found = false;
+
+			foreach ($tags as $tag)
+			{
+				if ($tag->name == $package->version)
+				{
+					$this->out($tag->name . ' <= Installed');
+
+					$found = true;
+
+					if (!$allTags)
+					{
+						break;
+					}
+				}
+				else
+				{
+					$this->out($tag->name);
+				}
+			}
+
+			if (!$found)
+			{
+				$this->out('Installed: ' . $package->version);
+			}
+
+			$this->out();
+		}
+
+		return $this;
+	}
+}


### PR DESCRIPTION
This adds a command to retrieve a list of tags for packages installed by composer and compare them against the installed version.

Current output:

```
$ ./cli/tracker.php get composertags
------------------------------------------------------------
              Joomla! Tracker CLI Application
                            1.1
------------------------------------------------------------
------------------------------------------------------------
                   Retrieve composer tags
------------------------------------------------------------
[2013-12-03 09:12:24] JTracker.INFO: Start getting composer tags. [] []

GitHub rate limit:... 5000 (remaining: 5000)

monolog/monolog
1.7.0
1.6.0 <= Installed

twig/twig
v1.14.2 <= Installed

filp/whoops
1.0.9 <= Installed

mustache/mustache
v2.4.1
v2.4.0
v2.3.1
v2.3.0
v2.2.0
v2.1.0 <= Installed

symfony/http-foundation
v2.4.0-RC1
v2.4.0-BETA2
v2.4.0-BETA1
v2.3.7 <= Installed

psr/log
1.0.0
Installed: dev-master

elkuku/console-progressbar
1.0 <= Installed

elkuku/g11n
2.1 <= Installed

raveren/kint
v0.9 <= Installed

squizlabs/php_codesniffer
1.5.0RC4
1.5.0RC3
1.5.0RC2
1.5.0RC1
1.5.0 <= Installed

joomla/framework
1.0-beta3
1.0-beta2
1.0-beta
1.0-alpha
1.0
Installed: dev-master
```

Available options:

```
--all   Show all tags or only the most recent.
```

e.g.

```
$ ./cli/tracker.php get composertags --all
...
monolog/monolog
1.7.0
1.6.0 <= Installed
1.5.0
1.4.1
1.4.0
1.3.1
1.3.0
1.2.1
1.2.0
1.1.0
1.0.2
1.0.1
1.0.0-RC1
1.0.0
...
```

Note: This only works for projects hosted on GitHub (currently)
