### PR TITLE
Documentation to Register an App

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For more information on the CLI script see the [CLI script documentation](Docume
 
 If you want the 'login with Github' button to work properly you'll need to register an app with Github. To do this manage your account at github.com and go to the applications page. Create a new application.
 
-You'll be asked for the application URL and the callback URL. This can be your test server or your localhost environment. As long as you enter the URL that your localhost app is running on. An example might be ```jissues.local```.
+You'll be asked for the application URL and the callback URL. This can be your test server or your localhost environment. As long as you enter the URL that your localhost app is running on. An example might be ```http://jissues.local```.
 
 Once you've registered the app at Github you'll receive a ```Client ID``` and a ```Client Secret```, enter these into your JTracker ```config.json``` file, along with your Github login credentials. You should now be able to login with Github successfully
 


### PR DESCRIPTION
I wanted to use the 'login with github' button on my localhost but it wouldn't work unless I configured an app at github. I added some basic info on how to do that.
