### PR TITLE
Add `--extension` parameter to language creation scripts

### DIFF
--- a/cli/CliApp/Command/Make/Langfiles.php
+++ b/cli/CliApp/Command/Make/Langfiles.php
@@ -8,6 +8,7 @@
 
 namespace CliApp\Command\Make;
 
+use CliApp\Command\TrackerCommandOption;
 use g11n\Language\Storage;
 use g11n\Support\ExtensionHelper;
 
@@ -27,6 +28,21 @@ class Langfiles extends Make
 	protected $description = 'Create and update language files.';
 
 	/**
+	 * Constructor.
+	 *
+	 * @since   1.0
+	 */
+	public function __construct()
+	{
+		$this->addOption(
+			new TrackerCommandOption(
+				'extension', '',
+				'Process only this extension'
+			)
+		);
+	}
+
+	/**
 	 * Execute the command.
 	 *
 	 * @return  void
@@ -44,18 +60,23 @@ class Langfiles extends Make
 
 		$languages = $this->getApplication()->get('languages');
 
-		foreach ($languages as $lang)
+		$reqExtension = $this->getApplication()->input->getCmd('extension');
+
+		if (!$reqExtension || $reqExtension == 'JTracker')
 		{
-			if ('en-GB' == $lang)
+			foreach ($languages as $lang)
 			{
-				continue;
+				if ('en-GB' == $lang)
+				{
+					continue;
+				}
+
+				$this->out('Processing: JTracker Core ' . $lang);
+				$this->processDomain('JTracker', 'Core', $lang);
+
+				$this->out('Processing: JTracker Template ' . $lang);
+				$this->processDomain('JTracker', 'Template', $lang);
 			}
-
-			$this->out('Processing: JTracker Core ' . $lang);
-			$this->processDomain('JTracker', 'Core', $lang);
-
-			$this->out('Processing: JTracker Template ' . $lang);
-			$this->processDomain('JTracker', 'Template', $lang);
 		}
 
 		// Process App templates
@@ -70,7 +91,12 @@ class Langfiles extends Make
 
 			$extension = $fileInfo->getFileName();
 
-			$this->out('Processing: ' . $extension);
+			if ($reqExtension && $reqExtension != $extension)
+			{
+				continue;
+			}
+
+			$this->out('Processing App: ' . $extension);
 
 			foreach ($languages as $lang)
 			{

--- a/cli/CliApp/Command/Make/Langtemplates.php
+++ b/cli/CliApp/Command/Make/Langtemplates.php
@@ -8,6 +8,8 @@
 
 namespace CliApp\Command\Make;
 
+use CliApp\Command\TrackerCommandOption;
+
 use g11n\g11n;
 use g11n\Language\Storage;
 use g11n\Support\ExtensionHelper;
@@ -35,6 +37,21 @@ class Langtemplates extends Make
 	protected $description = 'Create language file templates.';
 
 	/**
+	 * Constructor.
+	 *
+	 * @since   1.0
+	 */
+	public function __construct()
+	{
+		$this->addOption(
+			new TrackerCommandOption(
+				'extension', '',
+				'Process only this extension'
+			)
+		);
+	}
+
+	/**
 	 * Execute the command.
 	 *
 	 * @return  void
@@ -51,39 +68,44 @@ class Langtemplates extends Make
 
 		defined('JDEBUG') || define('JDEBUG', 0);
 
+		$reqExtension = $this->getApplication()->input->getCmd('extension');
+
 		// Cleanup
 		$this->delTree(JPATH_ROOT . '/cache/twig');
 
-		// Process core files
-		$extension = 'JTracker';
-		$domain    = 'Core';
+		if (!$reqExtension || $reqExtension == 'JTracker')
+		{
+			// Process core files
+			$extension = 'JTracker';
+			$domain    = 'Core';
 
-		$this->out('Processing: ' . $domain . ' ' . $extension);
+			$this->out('Processing: ' . $domain . ' ' . $extension);
 
-		$templatePath = Storage::getTemplatePath($extension, $domain);
+			$templatePath = Storage::getTemplatePath($extension, $domain);
 
-		$paths = array(ExtensionHelper::getDomainPath($domain));
+			$paths = array(ExtensionHelper::getDomainPath($domain));
 
-		$this->processTemplates($extension, $domain, 'php', $paths, $templatePath);
+			$this->processTemplates($extension, $domain, 'php', $paths, $templatePath);
 
-		// Process base template
+			// Process base template
 
-		$extension = 'JTracker';
-		$domain    = 'Template';
+			$extension = 'JTracker';
+			$domain    = 'Template';
 
-		$this->out('Processing: ' . $domain . ' ' . $extension);
+			$this->out('Processing: ' . $domain . ' ' . $extension);
 
-		$twigDir = JPATH_ROOT . '/cache/twig/JTracker';
+			$twigDir = JPATH_ROOT . '/cache/twig/JTracker';
 
-		$this->makePhpFromTwig(JPATH_ROOT . '/templates', $twigDir);
+			$this->makePhpFromTwig(JPATH_ROOT . '/templates', $twigDir);
 
-		$templatePath = JPATH_ROOT . '/templates/' . $extension . '/' . ExtensionHelper::$langDirName . '/templates/' . $extension . '.pot';
+			$templatePath = JPATH_ROOT . '/templates/' . $extension . '/' . ExtensionHelper::$langDirName . '/templates/' . $extension . '.pot';
 
-		$paths = array(ExtensionHelper::getDomainPath($domain));
+			$paths = array(ExtensionHelper::getDomainPath($domain));
 
-		$this->processTemplates($extension, $domain, 'php', $paths, $templatePath);
+			$this->processTemplates($extension, $domain, 'php', $paths, $templatePath);
 
-		$this->replacePaths(JPATH_ROOT . '/templates', $twigDir, $templatePath);
+			$this->replacePaths(JPATH_ROOT . '/templates', $twigDir, $templatePath);
+		}
 
 		// Process App templates
 
@@ -97,7 +119,12 @@ class Langtemplates extends Make
 
 			$extension = $fileInfo->getFileName();
 
-			$this->out('Processing: ' . $extension);
+			if ($reqExtension && $reqExtension != $extension)
+			{
+				continue;
+			}
+
+			$this->out('Processing App: ' . $extension);
 
 			$domain = 'App';
 


### PR DESCRIPTION
This will allow to process the language files for a specific extension only.

Example:
`tracker.php make lantemplates --extension=Users`

To process the "core" files use `--extension=JTracker`
