### PR TITLE
Remove call to external media

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -12,7 +12,6 @@
     <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ uri.base.path }}images/apple-touch-icon-114-precomposed.png">
     <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ uri.base.path }}images/apple-touch-icon-72-precomposed.png">
     <link rel="apple-touch-icon-precomposed" href="{{ uri.base.path }}images/apple-touch-icon-57-precomposed.png">
-    <link href="http://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">
     <style type="text/css">
         h1, h2, h3, h4, h5, h6, .site-title {
             font-family: 'Open Sans', sans-serif;


### PR DESCRIPTION
This is currently causing a `404` so I suggest to remove it.

Also if we decide to re-implement external CDN I think we should provide a config option to deactivate it. This will help in local off-line development ;)
