### PR TITLE
Change Vagrant base box to a custom box made by elkuku

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "wheezy-72-64-vb-43"
-    config.vm.box_url = "https://dl.dropboxusercontent.com/u/197673519/debian-7.2.0.box"
-    config.vm.provision :puppet do |puppet|
+  config.vm.box = "debian-7-64-elkuku-4"
+  config.vm.box_url = "https://dl.dropboxusercontent.com/s/nc9fdcl4mtgsve3/debian-7-64-elkuku-4.box"
+  config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "build/puppet/manifests"
   end
   config.vm.network :forwarded_port, host: 2345, guest: 80


### PR DESCRIPTION
The base box we are currently using is giving this funny error the last couple of days:
![dropboxs__509](https://f.cloud.github.com/assets/33978/2175227/c385e338-95bb-11e3-8ee4-5f88e6ef8b39.png)

Not sure if Dropbox mentions this anywhere, but "temporarily" lasts at least for the last three days...

So I decided to bake my own one and hope that it does not get too popular, since I also use [Dropbox](http://dropbox.com) to host it ;)

The first steps have been done using the excellent script from [dotzero/vagrant-debian-wheezy-64](https://github.com/dotzero/vagrant-debian-wheezy-64)
I then went on installing the latest VBox additions and tried to reduce it in size.

Please test.
