### PR TITLE
Remove language key creation from database entries - Fix #360

### DIFF
--- a/cli/Application/Command/Make/Langtemplates.php
+++ b/cli/Application/Command/Make/Langtemplates.php
@@ -165,53 +165,6 @@ class Langtemplates extends Make
 
 			$this->replacePaths(JPATH_ROOT . '/templates/' . strtolower($extension), JPATH_ROOT . '/cache/twig/' . $extension, $templatePath);
 		}
-
-		$this->processDatabase();
-	}
-
-	/**
-	 * A special routine to handle translation strings contained in the database.
-	 *
-	 * @return  $this
-	 *
-	 * @since   1.0
-	 */
-	protected function processDatabase()
-	{
-		/* @type \Joomla\Database\DatabaseDriver $db */
-		$db = $this->getContainer()->get('db');
-
-		$strings = $db->setQuery(
-			$db->getQuery(true)
-			->from('#__status')
-			->select('status')
-		)->loadColumn();
-
-		$path = JPATH_ROOT . '/src/App/Tracker/g11n/templates/Tracker.pot';
-
-		$contents = file_get_contents($path);
-
-		$starter = "\n# DATABASE TRANSLATIONS\n";
-
-		$pos = strpos($starter, $contents);
-
-		if ($pos)
-		{
-			$contents = substr($contents, 0, $pos);
-		}
-
-		$contents .= $starter;
-
-		foreach ($strings as $string)
-		{
-			$contents .= "\n#: DATABASE\n";
-			$contents .= "msgid \"$string\"\n";
-			$contents .= "msgstr \"\"\n";
-		}
-
-		file_put_contents($path, $contents);
-
-		return $this;
 	}
 
 	/**


### PR DESCRIPTION
Remove the automated database processing, since its MUCH better to actually "hard code" the language keys in the code (like it's done in #351), so the scanner scripts can "see" them.
