### PR TITLE
Make the priorities more clear

### DIFF
--- a/templates/tracker/issue.add.twig
+++ b/templates/tracker/issue.add.twig
@@ -43,8 +43,8 @@
                 <div class="divider">-</div>
 
                 {{ fields.label('priority', 'Priority'|_, '') }}
-                {% set priorities = [1, 2, 3, 4, 5] %}
-                {{ fields.selectequal('item[priority]', priorities, item.priority, 'priority', 'input-priority') }}
+                {% set priorities = {1: 'Critical'|_, 2: 'Urgent'|_, 3: 'Medium'|_, 4: 'Low'|_, 5: 'Very low'|_ } %}
+                {{ fields.select('item[priority]', priorities, item.priority, 'priority', 'input-small-100') }}
 
                 <div class="helpText alert alert-info">
                     {{ "The priority of which this issue should be resolved. Please see the <a href=\"http://docs.joomla.org/Bug_Tracking_Process\" target=\"blank\">Bug Tracking Process</a> page for detailed information about the project's priorities."|_|raw }}

--- a/templates/tracker/issue.edit.twig
+++ b/templates/tracker/issue.edit.twig
@@ -74,9 +74,11 @@
         </li>
         <li>
             <label for="priority">{{ translate('Priority') }}</label>
-            <select name="item[priority]" id="priority" class="span1">
-                {% for i in range(1, 5) %}
-                    <option {{ i == item.priority ? "selected='selected'" : ""  }} value="{{ i }}">{{ i }}</option>
+            <select name="item[priority]" id="priority" class="span2">
+                {% set priorities = {1: 'Critical'|_, 2: 'Urgent'|_, 3: 'Medium'|_, 4: 'Low'|_, 5: 'Very low'|_ } %}
+
+                {% for key, value in priorities %}
+                    <option {{ key == item.priority ? "selected='selected'" : ""  }} value="{{ key }}">{{ value }}</option>
                 {% endfor %}
             </select>
         </li>

--- a/templates/tracker/issues.index.twig
+++ b/templates/tracker/issues.index.twig
@@ -173,7 +173,8 @@
                             </div>
                         </td>
                         <td class="center valign-center">
-                            <span class="badge {{ prioClass(item.priority) }}">{{ item.priority  }}</span>
+                            {% set priorities = {1: 'Critical'|_, 2: 'Urgent'|_, 3: 'Medium'|_, 4: 'Low'|_, 5: 'Very low'|_ } %}
+                            <span class="badge {{ prioClass(item.priority) }}">{{ priorities[item.priority] }}</span>
                         </td>
                        <td class="center valign-center">
                             {{ item.status_title|_ }}

--- a/templates/tracker/tracker.filters.twig
+++ b/templates/tracker/tracker.filters.twig
@@ -30,7 +30,7 @@
 {% macro priority(value, id, class) %}
     {% import "fields.twig" as fields %}
 
-    {% set values = {0: '- priority -'|_, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5 } %}
+    {% set values = {0: '- priority -'|_, 1: 'Critical'|_, 2: 'Urgent'|_, 3: 'Medium'|_, 4: 'Low'|_, 5: 'Very low'|_ } %}
 
     {{ fields.select('filter-priority', values, value, id, class) }}
 {% endmacro %}


### PR DESCRIPTION
Based on today's feedback from users - make the priorities more clear. All priority numbers were changed to translatable values:

```
1: 'Critical'|_, 
2: 'Urgent'|_, 
3: 'Medium'|_, 
4: 'Low'|_, 
5: 'Very low'|_
```
