### PR TITLE
Add a 'use_cdn' config parameter

### DIFF
--- a/etc/config.dist.json
+++ b/etc/config.dist.json
@@ -35,7 +35,8 @@
 		"list_limit": "20",
 		"gzip"      : "0",
 		"offset"    : "UTC",
-		"upload_dir": "uploads"
+		"upload_dir": "uploads",
+		"use_cdn"   : "1"
 	},
 
 	"acl": {

--- a/etc/config.travis.json
+++ b/etc/config.travis.json
@@ -23,7 +23,8 @@
 	"system": {
 		"list_limit": "20",
 		"gzip"      : "0",
-		"offset"    : "UTC"
+		"offset"    : "UTC",
+		"use_cdn"   : "0"
 	},
 
 	"acl": {

--- a/etc/config.vagrant.json
+++ b/etc/config.vagrant.json
@@ -35,7 +35,8 @@
 		"list_limit" : "20",
 		"gzip"       : "0",
 		"offset"     : "UTC",
-		"upload_dir" : "uploads"
+		"upload_dir" : "uploads",
+		"use_cdn"    : "0"
 	},
 
 	"acl": {

--- a/src/JTracker/View/Renderer/TrackerExtension.php
+++ b/src/JTracker/View/Renderer/TrackerExtension.php
@@ -72,6 +72,7 @@ class TrackerExtension extends \Twig_Extension
 								? $application->getUser()->params->get('language')
 								: g11n::getCurrent(),
 			'g11nJavaScript' => g11n::getJavaScript(),
+			'useCDN'         => $application->get('system.use_cdn'),
 		);
 	}
 

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -12,7 +12,9 @@
     <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ uri.base.path }}images/apple-touch-icon-114-precomposed.png">
     <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ uri.base.path }}images/apple-touch-icon-72-precomposed.png">
     <link rel="apple-touch-icon-precomposed" href="{{ uri.base.path }}images/apple-touch-icon-57-precomposed.png">
+    {% if useCDN %}
     <link href="http://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">
+    {% endif %}
     <style type="text/css">
         h1, h2, h3, h4, h5, h6, .site-title {
             font-family: 'Open Sans', sans-serif;


### PR DESCRIPTION
This will add a parameter to use (or not) a CDN.
Currently this is only applied to a font which is loaded from Google.

This change is useful for local off line (or paid mobile) development :sad:
