### PR TITLE
Allow managers to add and remove labels on GitHub using a bot account

### DIFF
--- a/src/App/GitHub/Controller/Ajax/Labels/GetList.php
+++ b/src/App/GitHub/Controller/Ajax/Labels/GetList.php
@@ -26,7 +26,7 @@ class GetList extends AbstractAjaxController
 	 */
 	protected function prepareResponse()
 	{
-		$this->getContainer()->get('app')->getUser()->authorize('admin');
+		$this->getContainer()->get('app')->getUser()->authorize('manage');
 
 		$project = $this->getContainer()->get('app')->getProject();
 

--- a/src/App/GitHub/Controller/Labels.php
+++ b/src/App/GitHub/Controller/Labels.php
@@ -39,7 +39,7 @@ class Labels extends AbstractTrackerController
 	{
 		parent::initialize();
 
-		$this->getContainer()->get('app')->getUser()->authorize('admin');
+		$this->getContainer()->get('app')->getUser()->authorize('manage');
 
 		$this->view->setProject($this->getContainer()->get('app')->getProject());
 

--- a/src/App/Projects/Controller/Project.php
+++ b/src/App/Projects/Controller/Project.php
@@ -39,6 +39,9 @@ class Project extends AbstractTrackerController
 	 */
 	public function initialize()
 	{
+		// Reload the project.
+		$this->getContainer()->get('app')->getProject(true);
+
 		parent::initialize();
 
 		$this->view->setAlias($this->getContainer()->get('app')->input->get('project_alias'));

--- a/templates/projects/project.index.twig
+++ b/templates/projects/project.index.twig
@@ -9,18 +9,50 @@
 
 {% block content %}
 
+    {% if user.check('admin') %}
+        <div class="btn-group pull-right">
+            <a class="btn btn-info" href="{{ uri.base.path }}project/{{ project.alias }}/edit">{{ "Edit"|_ }}</a>
+            <a class="btn btn-danger" href="{{ uri.base.path }}project/{{ project.alias }}/delete">{{ "Delete"|_ }}</a>
+        </div>
+    {% endif %}
+
+
     <h2>{{ project.title }}</h2>
 
-    Some stuff about the Project here...
+    <p>Some stuff about the Project here...</p>
 
-    <ul class="unstyled">
-        {% if project.gh_user and project.gh_project %}
-            <li>
-                <a href="https://github.com/{{ project.gh_user }}/{{ project.gh_project }}">
-                    {{ "GitHub"|_ }}
-                </a>
-            </li>
-        {% endif %}
+<p>
+<a class="btn btn-success" href="{{ uri.base.path }}tracker/{{ project.alias }}">
+        {{ "Project %s Tracker"|_|format(project.title) }}
+    </a>
+    </p>
+
+    <ul>
+    {% if project.gh_user and project.gh_project %}
+        <li>
+            <i class="icon-github"></i>
+            <a href="https://github.com/{{ project.gh_user }}/{{ project.gh_project }}">
+                {{ "Project %s on GitHub"|_|format(project.gh_user ~ "/" ~ project.gh_project) }}
+            </a>
+        </li>
+        <li>
+            <a href="{{ uri.base.path }}project/{{ project.alias }}/stats">{{ "Statistics"|_ }}</a>
+        </li>
+    {% endif %}
+
+    {% if user.check('admin') %}
+        <li>
+            <a href="{{ uri.base.path }}project/{{ project.alias }}/hooks">{{ "Hooks"|_ }}</a>
+        </li>
+    {% endif %}
+
+    {% if user.check('manage') %}
+        <li>
+            <a href="{{ uri.base.path }}project/{{ project.alias }}/groups">{{ "Groups"|_ }}</a>
+        </li>
+        <li>
+            <a href="{{ uri.base.path }}project/{{ project.alias }}/labels">{{ "Labels"|_ }}</a>
+        </li>
+    {% endif %}
     </ul>
-
 {% endblock %}

--- a/templates/projects/projects.index.twig
+++ b/templates/projects/projects.index.twig
@@ -27,10 +27,7 @@
         <tr>
             <th>{{ "Tracker"|_ }}</th>
             <th><i class="icon-github"></i>&nbsp;{{ "GitHub"|_ }}</th>
-
-            {% if user.isAdmin %}
-                <th style="width: 10%;">{{ "Actions"|_ }}</th>
-            {% endif %}
+            <th>{{ "Actions"|_ }}</th>
 
             {% if jdebug %}
                 <th style="width: 5%;">{{ "Id"|_ }}</th>
@@ -56,14 +53,14 @@
                     {% endif %}
                 </td>
 
-                {% if user.isAdmin %}
                     <td style="white-space: nowrap;">
-                        <a href="{{ uri.base.path }}project/{{ project.alias }}/groups">{{ "Groups"|_ }}</a>
                         <a href="{{ uri.base.path }}project/{{ project.alias }}">{{ "Show"|_ }}</a>
+                    {% if user.isAdmin %}
+                        <a href="{{ uri.base.path }}project/{{ project.alias }}/groups">{{ "Groups"|_ }}</a>
                         <a href="{{ uri.base.path }}project/{{ project.alias }}/edit">{{ "Edit"|_ }}</a>
                         <a href="{{ uri.base.path }}project/{{ project.alias }}/delete">{{ "Delete"|_ }}</a>
+                    {% endif %}
                     </td>
-                {% endif %}
 
                 {% if jdebug %}
                   <td>{{ project.project_id }}</td>

--- a/templates/trackerMenu.twig
+++ b/templates/trackerMenu.twig
@@ -8,7 +8,7 @@
         {{ "Tracker"|_ }}
     </a>
 </li>
-{% if project.project_id and user.check("manage") %}
+{% if project.project_id %}
     <li class="dropdown {{ "project" == firstPart ? "active" : "" }}">
         <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:;">
             {{ "Project"|_ }}
@@ -26,14 +26,15 @@
             </li>
 
             {% if user.check("admin") %}
-                <li>
-                    <a href="{{ uri.base.path }}project/{{ project.alias }}/edit">
-                        <i class="icon-pencil"></i>
-                        {{ "Edit"|_ }}
-                    </a>
-                </li>
+            <li>
+                <a href="{{ uri.base.path }}project/{{ project.alias }}/edit">
+                    <i class="icon-pencil"></i>
+                    {{ "Edit"|_ }}
+                </a>
+            </li>
             {% endif %}
 
+            {% if user.check("manage") %}
             <li class="divider"><span></span></li>
 
             <li>
@@ -42,6 +43,13 @@
                     {{ "Access Groups"|_ }}
                 </a>
             </li>
+            <li>
+                <a href="{{ uri.base.path }}project/{{ project.alias }}/labels">
+                    <i class="icon-tag"></i>
+                    {{ "Labels"|_ }}
+                </a>
+            </li>
+            {% endif %}
         </ul>
     </li>
 {% endif %}


### PR DESCRIPTION
This will allow managers to add and remove labels for a project on GitHub using a bot account.

It does not cover label management for issues.
