### PR TITLE
Remove POC code

### DIFF
--- a/cli/Application/Command/Get/Project/Issues.php
+++ b/cli/Application/Command/Get/Project/Issues.php
@@ -289,7 +289,8 @@ class Issues extends Project
 					$status->description = 'JTracker Bug Squad working on it...';
 					$status->context = 'jtracker';
 
-					$this->createStatus($ghIssue, 'pending', 'http://issues.joomla.org/gagaga', 'JTracker Bug Squad working on it...', 'CI/JTracker');
+					// @todo Project based status messages
+					// @$this->createStatus($ghIssue, 'pending', 'http://issues.joomla.org/gagaga', 'JTracker Bug Squad working on it...', 'CI/JTracker');
 				}
 				else
 				{


### PR DESCRIPTION
There is some POC code that has been recently enabled and has now proven the concept.

Currently it sets a lot of PRs to "pending" with a test message (and 404 link), removing the Travis results.

We should
- Store the Travis test result and display it "somewhere".
- Add a meaningful, project based, message and link.

Example: https://github.com/joomla/joomla-cms/pull/4021
