### PR TITLE
Use a lookup to determine if the state should be changed by the cron script

### DIFF
--- a/src/App/Tracker/Table/StatusTable.php
+++ b/src/App/Tracker/Table/StatusTable.php
@@ -33,4 +33,24 @@ class StatusTable extends AbstractDatabaseTable
 	{
 		parent::__construct('#__status', 'id', $database);
 	}
+
+	/**
+	 * Retrieves an array of IDs for whether a status is open or closed
+	 *
+	 * @param   boolean  $state  True to fetch closed status IDs, false to retrieve open status IDs
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function getStateStatusIds($state)
+	{
+		// Build a query to fetch the status IDs based on open/close state
+		return $this->db->setQuery(
+			$this->db->getQuery(true)
+				->select('id')
+				->from($this->getTableName())
+				->where('closed = ' . (int) $state)
+		)->loadColumn();
+	}
 }


### PR DESCRIPTION
This is an alternate proposal for #408 which changes the CLI script to only change the issue status if the GitHub issue state has changed.  So, if an issue is already open and when the script runs the issue is now closed, then the status will be modified.  But, if an issue is open and that state hasn't changed, then we won't reset the issue status back to the default open state.

//cc @elkuku @zero-24
