### PR TITLE
Include link to local application instance in comment "signature"

### DIFF
--- a/src/App/Tracker/Controller/Comment/Ajax/Submit.php
+++ b/src/App/Tracker/Controller/Comment/Ajax/Submit.php
@@ -47,8 +47,10 @@ class Submit extends AbstractAjaxController
 
 		// @todo removeMe :(
 		$comment .= sprintf(
-			'<br />*You may blame the <a href="%1$s">%2$s Application</a> for transmitting this comment.*',
-			'https://github.com/joomla/jissues', 'J!Tracker'
+			'<br />*You may blame the <a href="%1$s">%2$s Application</a> at <a href="%3$s">%4$s</a> for transmitting this comment.*',
+			'https://github.com/joomla/jissues', 'J!Tracker',
+			$this->getContainer()->get('app')->get('uri')->base->full,
+			$this->getContainer()->get('app')->get('uri')->base->full
 		);
 
 		$project = $this->getContainer()->get('app')->getProject();


### PR DESCRIPTION
This will produce something like:

_You may blame the <a href="https://github.com/joomla/jissues">J!Tracker Application</a> at <a href="http://jtracker.local/">http://jtracker.local/</a> for transmitting this comment._

which includes a link to the "local" application instance (which will be, of course, http://issues.joomla.org on "our" product)
