### PR TITLE
Fix exception is thrown on unknown events

### DIFF
--- a/cli/Application/Command/Get/Project/Events.php
+++ b/cli/Application/Command/Get/Project/Events.php
@@ -303,7 +303,7 @@ class Events extends Project
 						break;
 
 					default:
-						throw new \UnexpectedValueException('Unknown event: ' . $event->event);
+						$this->logOut(sprintf('ERROR: Unknown Event: %s', $event->event));
 						continue;
 						break;
 				}


### PR DESCRIPTION
As suggested by @mbabker this will log an error on unknown events instead of throwing an exception.
Fix #403
