### PR TITLE
Fix bug in latest filter package. Fixes #579

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "joomla/date": "~1.1",
         "joomla/di": "~1.1",
         "joomla/event": "~1.1",
-        "joomla/filter": "1.1.2",
+        "joomla/filter": "~1.1",
         "joomla/github": "~1.2",
         "joomla/http": "~1.1",
         "joomla/input": "~1.1",

--- a/src/App/Tracker/Model/IssueModel.php
+++ b/src/App/Tracker/Model/IssueModel.php
@@ -379,6 +379,18 @@ class IssueModel extends AbstractTrackerDatabaseModel
 			throw new \RuntimeException('Missing ID');
 		}
 
+		// If the data rel_type is 0 then we haven't had one given. So make it null in that case.
+		if ($data['rel_type'] === 0)
+		{
+			$data['rel_type'] = null;
+		}
+
+		// If we don't have a milestone given it gets set to 0. So make it null in that case.
+		if ($data['milestone_id'] === 0)
+		{
+			$data['milestone_id'] = null;
+		}
+
 		$table = new IssuesTable($this->db);
 
 		$table->load($data['id'])

--- a/templates/fields.twig
+++ b/templates/fields.twig
@@ -57,7 +57,7 @@
 {% macro selectMilestone(name, items, selected, id, class) %}
     <select name="{{ name }}" id="{{ id|default(name) }}" class="selectpicker{% if class %} {{ class }}{% endif %}"
         title="{{ 'Select Milestone...'|_ }}">
-        <option {% if null == selected %} selected="selected"{% endif %}>{{ 'No Milestone'|_ }}</option>
+        <option value="0" {% if null == selected %} selected="selected"{% endif %}>{{ 'No Milestone'|_ }}</option>
         {% for item in items %}
             <option value="{{ item.milestone_id }}" {% if item.milestone_id == selected %} selected="selected"{% endif %}>
                 {{ item.title }}

--- a/templates/tracker/issue.edit.twig
+++ b/templates/tracker/issue.edit.twig
@@ -87,7 +87,7 @@
         <li>
             <label for="rel_type">{{ translate('Item') }}</label>
             <select name="item[rel_type]" id="rel_type" class="span2">
-                <option></option>
+                <option value="0"></option>
                 {% for relType in getRelTypes() %}
                     {% set selected = item.rel_type == relType.value ? 'selected="selected"' : '' %}
                     <option {{ selected }} value="{{ relType.value }}">{{ relType.text }}</option>


### PR DESCRIPTION
"If the value attribute is not specified, the content will be passed as a value instead." (http://www.w3schools.com/tags/att_option_value.asp - the most reliable source ever).

Michael stated in #579 that the values from the database where

```
["rel_type"] => string(0) ""
["milestone_id"] => string(12) "No Milestone"
```

This fixes that by specifying a default value of 0 for both fields (which isn't a possible relation for the 2 fields). If this value is met then in the model they are set to null (note I don't know whether these checks for 0 are better done in model or table - I was strongly tempted to put them into App\Tracker\Table\IssuesTable::check() function tbh)

Note I have absolutely no virtual box for this thing set up so you MUST test this before merging