### PR TITLE
Fix #584 - permalink button

### DIFF
--- a/templates/tracker/issues.index.twig
+++ b/templates/tracker/issues.index.twig
@@ -502,6 +502,7 @@
                     $('#issuesList tbody').animate({opacity: 1}, 100);
 
                     var categoryText = $('#filter-category option:selected').text();
+
                     $('#permalink').attr('href', getPermaLink(
                             search, status, priority, user, sort, state, category, categoryText, label, tests, easytest, created_by
                     ));
@@ -513,6 +514,15 @@
             var permaLink = '{{ uri.base.path }}tracker/{{ project.alias }}/?';
             var filters = [];
             var stools = [];
+
+            // Replace non alpha numeric chars with dash
+            categoryText = categoryText.replace(/[\W_]+/g,'-');
+
+            // Remove the last dash if exists
+            if (categoryText.charAt(categoryText.length - 1) == '-')
+            {
+                categoryText = categoryText.slice(0, - 1);
+            }
 
             if (state != 0) { filters[filters.length] = 'state=' + state; }
 

--- a/templates/tracker/issues.index.twig
+++ b/templates/tracker/issues.index.twig
@@ -503,13 +503,13 @@
 
                     var categoryText = $('#filter-category option:selected').text();
                     $('#permalink').attr('href', getPermaLink(
-                            search, status, priority, user, sort, state, category, categoryText, label, tests, easytest
+                            search, status, priority, user, sort, state, category, categoryText, label, tests, easytest, created_by
                     ));
                 }
             });
         }
 
-        function getPermaLink(search, status, priority, user, sort, state, category, categoryText, label, tests, easytest) {
+        function getPermaLink(search, status, priority, user, sort, state, category, categoryText, label, tests, easytest, created_by) {
             var permaLink = '{{ uri.base.path }}tracker/{{ project.alias }}/?';
             var filters = [];
             var stools = [];
@@ -525,6 +525,7 @@
             if (label != 0) { stools[stools.length] = 'label=' + label }
             if (tests != 0) { stools[stools.length] = 'tests=' + tests }
             if (easytest != 0) { stools[stools.length] = 'easytest=' + easytest }
+            if (created_by != 0) { stools[stools.length] = 'created_by=' + created_by }
 
             permaLink += filters.length ? filters.join('&') + '&' : '';
 

--- a/templates/tracker/issues.index.twig
+++ b/templates/tracker/issues.index.twig
@@ -524,13 +524,33 @@
                 categoryText = categoryText.slice(0, - 1);
             }
 
+            // Process sorting
+            sort = parseInt(sort);
+            var sorting = '';
+
+            switch (sort) {
+                case 1 :
+                    sorting = 'sort=issue&direction=asc';
+                    break;
+                case 2 :
+                    sorting = 'sort=updated&direction=desc';
+                    break;
+                case 3 :
+                    sorting = 'sort=updated&direction=asc';
+                    break;
+                default :
+                    sorting = 'sort=issue&direction=desc';
+            }
+
+            stools[stools.length] = '' + sorting;
+
+            // Add other filters
             if (state != 0) { filters[filters.length] = 'state=' + state; }
 
             if (search) { stools[stools.length] = 'search=' + search }
             if (status != 0) { stools[stools.length] = 'status=' + status }
             if (priority != 0) { stools[stools.length] = 'priority=' + priority }
             if (user != 0) { stools[stools.length] = 'user=' + user }
-            if (sort != 0) { stools[stools.length] = 'sort=' + sort }
             if (category != 0) { stools[stools.length] = 'category=' + categoryText.toLowerCase() }
             if (label != 0) { stools[stools.length] = 'label=' + label }
             if (tests != 0) { stools[stools.length] = 'tests=' + tests }

--- a/www/jtracker/core/css/template.css
+++ b/www/jtracker/core/css/template.css
@@ -8761,3 +8761,8 @@ div#nav-search form input[type="text"] {
 .subnav-wrapper {
   margin-bottom: 22px;
 }
+@media (min-width: 768px) {
+  a#permalink{
+    margin-right: 5px;
+  }
+}


### PR DESCRIPTION
This PR will replace non alpha numeric characters in category name from the categories filter and will allow permalink button to work correctly.

But to make it work all aliases of the categories should be named (renamed) using the common pattern:
1. Spaces and non alpha numeric characters should be replaced with dash. 
2. Short names are not allowed

For example:
```
Router / Sef - router-sef
External Library - external-library
Language & Strings - language-strings
Templates (admin) - templates-admin
```

Also this PR will add `created_by` to permalink button.

As always you are welcome to test it on my [JIssues test website](http://jtracker.j4devs.ru/tracker/jtests)