### PR TITLE
Project specific actions

### DIFF
--- a/cli/Application/Command/Get/Get.php
+++ b/cli/Application/Command/Get/Get.php
@@ -41,14 +41,6 @@ class Get extends TrackerCommand
 	protected $botId = 0;
 
 	/**
-	 * Project object.
-	 *
-	 * @var    ProjectsTable
-	 * @since  1.0
-	 */
-	protected $project = null;
-
-	/**
 	 * Transifex object
 	 *
 	 * @var    Transifex

--- a/cli/Application/Command/Get/Project/Issues.php
+++ b/cli/Application/Command/Get/Project/Issues.php
@@ -309,7 +309,7 @@ class Issues extends Project
 				{
 					$gitHub = GithubFactory::getInstance(
 						$this->getApplication(), true,
-						$this->project->getGh_Editbot_User() && $this->project->getGh_Editbot_Pass()
+						$this->project->getGh_Editbot_User(), $this->project->getGh_Editbot_Pass()
 					);
 
 					$this->project->runActions(

--- a/cli/Application/Command/Get/Project/Issues.php
+++ b/cli/Application/Command/Get/Project/Issues.php
@@ -244,6 +244,7 @@ class Issues extends Project
 
 			// Store the item in the database
 			$table = new IssuesTable($this->getContainer()->get('db'));
+			$pullRequest = null;
 
 			if ($id)
 			{
@@ -304,19 +305,6 @@ class Issues extends Project
 
 				$table->pr_head_user = $pullRequest->head->user->login;
 				$table->pr_head_ref  = $pullRequest->head->ref;
-
-				if ($this->project->getGh_Editbot_User() && $this->project->getGh_Editbot_Pass())
-				{
-					$gitHub = GithubFactory::getInstance(
-						$this->getApplication(), true,
-						$this->project->getGh_Editbot_User(), $this->project->getGh_Editbot_Pass()
-					);
-
-					$this->project->runActions(
-						'GitHub', 'UpdateStatus',
-						['pullRequest' => $pullRequest, 'GitHub' => $gitHub]
-					);
-				}
 
 				if (0)
 				{
@@ -390,6 +378,19 @@ class Issues extends Project
 				$activity->store();
 			}
 			*/
+
+			if ($pullRequest && $this->project->getGh_Editbot_User() && $this->project->getGh_Editbot_Pass())
+			{
+				$gitHub = GithubFactory::getInstance(
+					$this->getApplication(), true,
+					$this->project->getGh_Editbot_User(), $this->project->getGh_Editbot_Pass()
+				);
+
+				$this->project->runActions(
+					'GitHub', 'UpdateStatus',
+					['pullRequest' => $pullRequest, 'GitHub' => $gitHub]
+				);
+			}
 
 			// Store was successful, update status
 			if ($id)

--- a/cli/Application/Command/TrackerCommand.php
+++ b/cli/Application/Command/TrackerCommand.php
@@ -280,7 +280,7 @@ abstract class TrackerCommand implements LoggerAwareInterface, ContainerAwareInt
 		$projects = $db->setQuery(
 			$db->getQuery(true)
 				->from($db->quoteName('#__tracker_projects'))
-				->select(array('project_id', 'title', 'gh_user', 'gh_project', 'gh_editbot_user', 'gh_editbot_pass'))
+				->select(array('project_id', 'title', 'alias', 'gh_user', 'gh_project', 'gh_editbot_user', 'gh_editbot_pass'))
 
 		)->loadObjectList();
 

--- a/cli/Application/Command/TrackerCommand.php
+++ b/cli/Application/Command/TrackerCommand.php
@@ -280,14 +280,10 @@ abstract class TrackerCommand implements LoggerAwareInterface, ContainerAwareInt
 		$projects = $db->setQuery(
 			$db->getQuery(true)
 				->from($db->quoteName('#__tracker_projects'))
-				->select(array('project_id', 'title', 'gh_user', 'gh_project'))
+				->select(array('project_id', 'title', 'gh_user', 'gh_project', 'gh_editbot_user', 'gh_editbot_pass'))
 
 		)->loadObjectList();
-/*
-		$projectsModel = new ProjectsModel($this->getContainer()->get('db'), $this->getApplication()->input);
-		$user = new GitHubUser($this->getApplication()->getp);
-		$projects = with()->getItems();
-*/
+
 		$id = $this->getApplication()->input->getInt('project', $this->getApplication()->input->getInt('p'));
 
 		if (!$id)
@@ -325,7 +321,7 @@ abstract class TrackerCommand implements LoggerAwareInterface, ContainerAwareInt
 				throw new AbortException(g11n3t('Invalid project'));
 			}
 
-			$this->project = $checks[$resp];
+			$this->project = new TrackerProject($db, $checks[$resp]);
 		}
 		else
 		{
@@ -333,7 +329,7 @@ abstract class TrackerCommand implements LoggerAwareInterface, ContainerAwareInt
 			{
 				if ($project->project_id == $id)
 				{
-					$this->project = $project;
+					$this->project = new TrackerProject($db, $project);
 
 					break;
 				}

--- a/etc/mysql.sql
+++ b/etc/mysql.sql
@@ -361,3 +361,16 @@ CREATE TABLE `#__issue_category_map` (
   CONSTRAINT `#__issue_category_map_ibfk_1` FOREIGN KEY (`issue_id`) REFERENCES `#__issues` (`id`),
   CONSTRAINT `#__issue_category_map_ibfk_2` FOREIGN KEY (`category_id`) REFERENCES `#__issues_categories` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+
+-- --
+-- Table structure for table `#__tracker_actions`
+--
+CREATE TABLE IF NOT EXISTS `#__tracker_actions` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT COMMENT 'PK',
+  `project_id` int(11) NOT NULL COMMENT 'The id of the Project',
+  `type` varchar(150) NOT NULL COMMENT 'The action type',
+  `name` varchar(150) NOT NULL COMMENT 'The action name',
+  `params` longtext NOT NULL COMMENT 'The action parameters'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/src/App/Projects/Action/AbstractAction.php
+++ b/src/App/Projects/Action/AbstractAction.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Part of the Joomla! Tracker
+ *
+ * @copyright  Copyright (C) 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Projects\Action;
+
+use App\Projects\TrackerProject;
+
+use Joomla\Database\DatabaseDriver;
+
+/**
+ * Class AbstractAction
+ *
+ * @since  1.0
+ */
+abstract class AbstractAction
+{
+	/**
+	 * Project object.
+	 *
+	 * @var    TrackerProject
+	 * @since  1.0
+	 */
+	protected $project = null;
+
+	/**
+	 * @var    DatabaseDriver
+	 * @since  1.0
+	 */
+	protected $database = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   TrackerProject  $project   The project.
+	 * @param   DatabaseDriver  $database  The database object.
+	 *
+	 * @since   1.0
+	 */
+	public function __construct(TrackerProject $project, DatabaseDriver $database)
+	{
+		$this->project  = $project;
+		$this->database = $database;
+	}
+
+	/**
+	 * Run the action.
+	 *
+	 * @param   array   $params        Parameters.
+	 * @param   object  $actionParams  Parameters for the action.
+	 *
+	 * @since   1.0
+	 *
+	 * @return mixed
+	 */
+	abstract public function run(array $params, $actionParams);
+
+	/**
+	 * Check if all required parameters are set.
+	 *
+	 * @param   array  $params  Parameters.
+	 * @param   array  $types   Parameter types to check for.
+	 *
+	 * @since   1.0
+	 *
+	 * @return $this
+	 */
+	protected function checkParams(array $params, array $types)
+	{
+		foreach ($types as $type)
+		{
+			if (false == array_key_exists($type, $params))
+			{
+				throw new \UnexpectedValueException(
+					sprintf('Action of type %1$s not found in params for class %2$s', $type, __CLASS__)
+				);
+			}
+		}
+
+		return $this;
+	}
+}

--- a/src/App/Projects/Action/GitHub/AbstractGitHub.php
+++ b/src/App/Projects/Action/GitHub/AbstractGitHub.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Part of the Joomla! Tracker
+ *
+ * @copyright  Copyright (C) 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Projects\Action\GitHub;
+
+use App\Projects\Action\AbstractAction;
+
+use JTracker\GitHub\Github;
+
+/**
+ * Class AbstractGitHub
+ *
+ * @since  1.0
+ */
+class AbstractGitHub extends AbstractAction
+{
+	/**
+	 * @var GitHub
+	 */
+	private $gitHub;
+
+	/**
+	 * Get a GitHub object.
+	 *
+	 * @since   1.0
+	 *
+	 * @return Github
+	 */
+	public function getGitHub()
+	{
+		if (!$this->gitHub)
+		{
+			throw new \UnexpectedValueException('GitHub object not set!');
+		}
+
+		return $this->gitHub;
+	}
+
+	/**
+	 * Set the GitHub object.
+	 *
+	 * @param   Github  $gitHub  The GitHub object
+	 *
+	 * @since   1.0
+	 *
+	 * @return  $this
+	 */
+	public function setGitHub($gitHub)
+	{
+		$this->gitHub = $gitHub;
+
+		return $this;
+	}
+
+	/**
+	 * Run the action.
+	 *
+	 * @param   array   $params        Parameters.
+	 * @param   object  $actionParams  Parameters for the action.
+	 *
+	 * @since   1.0
+	 *
+	 * @return mixed
+	 */
+	public function run(array $params, $actionParams)
+	{
+		throw new \RuntimeException(__METHOD__ . ' must be implemented in child class!');
+	}
+}

--- a/src/App/Projects/Action/GitHub/UpdateStatus.json
+++ b/src/App/Projects/Action/GitHub/UpdateStatus.json
@@ -1,0 +1,29 @@
+{
+  "humanTestResults": {
+    "active": "bool",
+    "pending": {
+      "comp_success": "str[<>=]",
+      "cnt_success": "int",
+      "comp_failure": "str[<>=]",
+      "cnt_failure": "int"
+    },
+    "success": {
+      "comp_success": "str[<>=]",
+      "cnt_success": "int",
+      "comp_failure": "str[<>=]",
+      "cnt_failure": "int"
+    },
+    "error": {
+      "comp_success": "str[<>=]",
+      "cnt_success": "int",
+      "comp_failure": "str[<>=]",
+      "cnt_failure": "int"
+    },
+    "failure": {
+      "comp_success": "str[<>=]",
+      "cnt_success": "int",
+      "comp_failure": "str[<>=]",
+      "cnt_failure": "int"
+    }
+  }
+}

--- a/src/App/Projects/Action/GitHub/UpdateStatus.php
+++ b/src/App/Projects/Action/GitHub/UpdateStatus.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Part of the Joomla! Tracker
+ *
+ * @copyright  Copyright (C) 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Projects\Action\GitHub;
+
+use App\Tracker\Model\IssueModel;
+
+use JTracker\Github\DataType\Commit\Status;
+
+/**
+ * Class UpdateStatus
+ *
+ * @since  1.0
+ */
+class UpdateStatus extends AbstractGitHub
+{
+	/**
+	 * The pull request object.
+	 * @var   object
+	 */
+	private $pullRequest;
+
+	/**
+	 * Run the action.
+	 *
+	 * @param   array   $params        Parameters.
+	 * @param   object  $actionParams  Parameters for the action.
+	 *
+	 * @since   1.0
+	 *
+	 * @return mixed
+	 */
+	public function run(array $params, $actionParams)
+	{
+		$this->checkParams($params, ['GitHub', 'pullRequest']);
+
+		$this->pullRequest = $params['pullRequest'];
+		$this->setGitHub($params['GitHub']);
+
+		foreach ($actionParams as $type => $actionParam)
+		{
+			if ('1' != $actionParam->active)
+			{
+				continue;
+			}
+
+			if (false == method_exists($this, $type))
+			{
+				throw new \UnexpectedValueException(
+					sprintf(
+						'Method"%1$s"does not exist in class"%2$s"', $type, __CLASS__
+					)
+				);
+			}
+
+			unset($actionParam->active);
+
+			$status = $this->$type($actionParam);
+
+			if ($status->state)
+			{
+				$this->createStatus($this->pullRequest->number, $status);
+			}
+		}
+	}
+
+	/**
+	 * Get a merge status for human test results.
+	 *
+	 * @param   object  $actionParam  The action params object.
+	 *
+	 * @since 1.0
+	 *
+	 * @return Status
+	 */
+	private function humanTestResults($actionParam)
+	{
+		$model = new IssueModel($this->database);
+
+		$model->setProject($this->project);
+
+		$issue = $model->getItem($this->pullRequest->number);
+
+		$cntSuccess = count($issue->testsSuccess);
+		$cntFailure = count($issue->testsFailure);
+
+		$status = new Status;
+
+		foreach ($actionParam as $type => $checks)
+		{
+			$comp_success = $this->cleanComp($checks->comp_success);
+			$comp_failure = $this->cleanComp($checks->comp_failure);
+
+			$stateSuccess = false;
+			$stateFailure = false;
+
+			if ($comp_success)
+			{
+				$checkSuccess = $cntSuccess . $comp_success . (int) $checks->cnt_success;
+
+				if (eval('return ' . $checkSuccess . ';'))
+				{
+					$stateSuccess = true;
+				}
+			}
+
+			if ($comp_failure)
+			{
+				$checkFailure = $cntFailure . $comp_failure . (int) $checks->cnt_failure;
+
+				if (eval('return ' . $checkFailure . ';'))
+				{
+					$stateFailure = true;
+				}
+			}
+
+			if ($stateSuccess && $stateFailure)
+			{
+				$status->state = $type;
+				$status->description = sprintf('Human Test Results: %1$d Successful %2$d Failed.', $cntSuccess, $cntFailure);
+				$status->context = 'JTracker/HumanTestResults';
+
+				// @todo - where to get the URL from a CLI script?
+				$status->targetUrl = '' . $this->pullRequest->number;
+
+				return $status;
+			}
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Create a GitHub merge status for the last commit in a PR.
+	 *
+	 * @param   integer  $issueNumber  The issue number.
+	 * @param   Status   $status       The status object.
+	 * @param   string   $sha          The SHA of the corresponding commit.
+	 *
+	 * @since    1.0
+	 *
+	 * @return  object
+	 */
+	private function createStatus($issueNumber, Status $status, $sha = '')// $state, $targetUrl, $description, $context)
+	{
+		if (!$sha)
+		{
+			// Get the SHA of the last commit.
+			$pullRequest = $this->getGitHub()->pulls->get(
+				$this->project->gh_user, $this->project->gh_project, $issueNumber
+			);
+
+			$sha = $pullRequest->head->sha;
+		}
+
+		return $this->getGitHub()->repositories->statuses->create(
+			$this->project->gh_user, $this->project->gh_project, $sha,
+			$status->state, $status->targetUrl, $status->description, $status->context
+		);
+	}
+
+	/**
+	 * Clean up a string.
+	 *
+	 * @param   string  $string  The string to clean.
+	 *
+	 * @since    1.0
+	 *
+	 * @return  string
+	 */
+	private function cleanComp($string)
+	{
+		$string = preg_replace('/[^=<>]/', '', $string);
+
+		if ('=' == $string)
+		{
+			$string = '==';
+		}
+
+		return $string;
+	}
+}

--- a/src/App/Projects/Action/GitHub/UpdateStatus.php
+++ b/src/App/Projects/Action/GitHub/UpdateStatus.php
@@ -42,25 +42,25 @@ class UpdateStatus extends AbstractGitHub
 		$this->pullRequest = $params['pullRequest'];
 		$this->setGitHub($params['GitHub']);
 
-		foreach ($actionParams as $type => $actionParam)
+		foreach ($actionParams as $method => $actionParam)
 		{
 			if ('1' != $actionParam->active)
 			{
 				continue;
 			}
 
-			if (false == method_exists($this, $type))
+			if (false == method_exists($this, $method))
 			{
 				throw new \UnexpectedValueException(
 					sprintf(
-						'Method"%1$s"does not exist in class"%2$s"', $type, __CLASS__
+						'Method"%1$s"does not exist in class"%2$s"', $method, __CLASS__
 					)
 				);
 			}
 
 			unset($actionParam->active);
 
-			$status = $this->$type($actionParam);
+			$status = $this->$method($actionParam);
 
 			if ($status->state)
 			{
@@ -125,8 +125,10 @@ class UpdateStatus extends AbstractGitHub
 				$status->description = sprintf('Human Test Results: %1$d Successful %2$d Failed.', $cntSuccess, $cntFailure);
 				$status->context = 'JTracker/HumanTestResults';
 
-				// @todo - where to get the URL from a CLI script?
-				$status->targetUrl = '' . $this->pullRequest->number;
+				// @todo - where to get the URL from a CLI script? - create a config setting??
+				$targetBaseUrl = 'http://issues.joomla.org';
+
+				$status->targetUrl = $targetBaseUrl . '/tracker/' . $this->project->alias . '/' . $this->pullRequest->number;
 
 				return $status;
 			}
@@ -146,7 +148,7 @@ class UpdateStatus extends AbstractGitHub
 	 *
 	 * @return  object
 	 */
-	private function createStatus($issueNumber, Status $status, $sha = '')// $state, $targetUrl, $description, $context)
+	private function createStatus($issueNumber, Status $status, $sha = '')
 	{
 		if (!$sha)
 		{

--- a/src/App/Projects/Action/GitHub/UpdateStatus.php
+++ b/src/App/Projects/Action/GitHub/UpdateStatus.php
@@ -58,9 +58,11 @@ class UpdateStatus extends AbstractGitHub
 				);
 			}
 
-			unset($actionParam->active);
+			$p = clone($actionParam);
 
-			$status = $this->$method($actionParam);
+			unset($p->active);
+
+			$status = $this->$method($p);
 
 			if ($status->state)
 			{

--- a/src/App/Projects/Table/ActionsTable.php
+++ b/src/App/Projects/Table/ActionsTable.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Part of the Joomla! Tracker
+ *
+ * @copyright  Copyright (C) 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Projects\Table;
+
+use Joomla\Database\DatabaseDriver;
+
+use JTracker\Database\AbstractDatabaseTable;
+
+/**
+ * Table interface class for the #__tracker_actions table
+ *
+ * @property   integer  $id          PK
+ * @property   integer  $project_id  Project ID.
+ * @property   string   $type        Action type.
+ * @property   string   $name        Action name.
+ * @property   string   $params      JSON encoded param string.
+ *
+ * @since  1.0
+ */
+class ActionsTable extends AbstractDatabaseTable
+{
+	/**
+	 * Constructor
+	 *
+	 * @param   DatabaseDriver  $database  A database connector object
+	 *
+	 * @since   1.0
+	 */
+	public function __construct(DatabaseDriver $database)
+	{
+		parent::__construct('#__tracker_actions', 'id', $database);
+	}
+}

--- a/src/App/Tracker/Controller/TestResult/AbstractTest.php
+++ b/src/App/Tracker/Controller/TestResult/AbstractTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Tracker Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Tracker\Controller\TestResult;
+
+use App\Tracker\Model\ActivityModel;
+use App\Tracker\Model\IssueModel;
+
+use JTracker\Controller\AbstractAjaxController;
+use JTracker\Github\GithubFactory;
+
+/**
+ * Abstract test result controller class.
+ *
+ * @since  1.0
+ */
+abstract class AbstractTest extends AbstractAjaxController
+{
+	/**
+	 * Add a human test result.
+	 *
+	 * @param   string   $eventType  The event type.
+	 * @param   integer  $itemId     The item id.
+	 * @param   string   $userName   The username.
+	 * @param   integer  $result     The test result.
+	 *
+	 * @since  1.0
+	 *
+	 * @return  object
+	 */
+	protected function addTest($eventType, $itemId, $userName, $result)
+	{
+		/* @type \JTracker\Application $application */
+		$application = $this->getContainer()->get('app');
+		$user        = $application->getUser();
+		$project     = $application->getProject();
+		$issueModel = new IssueModel($this->getContainer()->get('db'));
+
+		$data   = new \stdClass;
+
+		$data->testResults = $issueModel
+			->saveTest($itemId, $userName, $result);
+
+		$resultData = new \stdClass;
+
+		$resultData->user = $userName;
+		$resultData->value = $result;
+
+		$event = (new ActivityModel($this->getContainer()->get('db')))
+			->addActivityEvent(
+				$eventType, 'now', $user->username,
+				$project->project_id,
+				$issueModel->getIssueNumberById($itemId),
+				null, json_encode($resultData)
+			);
+
+		$data->event = new \stdClass;
+
+		foreach ($event as $k => $v)
+		{
+			$data->event->$k = $v;
+		}
+
+		$data->event->text = json_decode($data->event->text);
+
+		return json_encode($data);
+	}
+
+	/**
+	 * Update a status on GitHub.
+	 *
+	 * @param   integer  $itemId  The item id.
+	 *
+	 * @since  1.0
+	 *
+	 * @return $this
+	 */
+	protected function updateStatus($itemId)
+	{
+		/* @type \JTracker\Application $application */
+		$application = $this->getContainer()->get('app');
+		$project     = $application->getProject();
+
+		if ($project->getGh_Editbot_User() && $project->getGh_Editbot_Pass())
+		{
+			$issueModel = new IssueModel($this->getContainer()->get('db'));
+
+			$gitHub = GithubFactory::getInstance(
+				$this->getContainer()->get('app'), true,
+				$project->getGh_Editbot_User(), $project->getGh_Editbot_Pass()
+			);
+
+			$pullRequest = $gitHub->pulls->get(
+				$project->gh_user, $project->gh_project, $issueModel->getIssueNumberById($itemId)
+			);
+
+			$project->runActions(
+				'GitHub', 'UpdateStatus',
+				['pullRequest' => $pullRequest, 'GitHub' => $gitHub]
+			);
+		}
+
+		return $this;
+	}
+}

--- a/templates/projects/project.edit.twig
+++ b/templates/projects/project.edit.twig
@@ -92,6 +92,9 @@
             <input type="hidden" name="project[project_id]" value="{{ project.project_id }}">
 
         </fieldset>
+        <fieldset>
+            <legend>{{ 'Actions'|_ }}</legend>
+        </fieldset>
     </form>
-
+{{ dump(project) }}
 {% endblock %}

--- a/templates/tracker/issue.index.twig
+++ b/templates/tracker/issue.index.twig
@@ -407,7 +407,12 @@
                     <b>{{ activity.user }}</b>
                     - <a href="/{{ uri.route }}#event-{{ activity.activities_id }}">{{ activity.event }}</a>
                     - <span title="{{ activity.created_date|date("j M Y H:i:s") }}"><i class="icon-calendar"></i>{{ activity.created_date|date("j M y") }}</span>
+                    {% if change.value is defined %}
+                    - <span class="tests-{{ change.value }}">{{ userTestOptions(change.value) }}</span>
+                    {% else %}
+                    {# legacy... #}
                     - <span class="tests-{{ change }}">{{ userTestOptions(change) }}</span>
+                    {% endif %}
                 </div>
             {% elseif 'alter_testresult' == activity.event %}
                 {% set change = activity.text|json_decode %}


### PR DESCRIPTION
### Project specific actions
The purpose of this is to introduce project specific behaviours consisting of some common PHP code and project specific settings stored in the database.
In the Joomla! world this would be Plugins&reg;

I am not sure about the implementation, so this is just a first scratch (but it should work) and I am wide open for suggestions ;)

### Update GitHub status for human test results (JBS)
So this would be the first implementation.

![bildschirmfoto von 2015-01-24 15 58 38](https://cloud.githubusercontent.com/assets/33978/5889041/4b9ba41c-a3e2-11e4-8421-cf4aea495eaa.png)

It works similar to those automated services like Travis, Scrutinizer etc. but for human test results created by our JTracker Application with the help of our community members from the JBS and others - it wouldn't work without them :)

GitHub allows four different status states called `pending`, `success`, `error` and `failure`.

So we might use three of them and map our human test results to something like:

* `pending` - less than `2` successful and `0` failing tests.
* `success` - `2` or more successful and `0` failing tests.
* `failure` - `0` or more successful and `1` or more failing tests.

See: [GitHub API - Create a status](https://developer.github.com/v3/repos/statuses/#create-a-status)

#### @test

This would be the database entry to activate the update status action for a project.

You should probably use a test project for testing...

```
INSERT INTO `#__tracker_actions` (`id`, `project_id`, `type`, `name`, `params`) VALUES
(1, 4, 'GitHub', 'UpdateStatus', '
{
  "humanTestResults": {
    "active": "1",
    "pending": {
      "comp_success": "<",
      "cnt_success": "2",
      "comp_failure": "=",
      "cnt_failure": "0"
    },
    "success": {
      "comp_success": ">=",
      "cnt_success": "2",
      "comp_failure": "=",
      "cnt_failure": "0"
    },
    "error": {
      "comp_success": "",
      "cnt_success": "",
      "comp_failure": "",
      "cnt_failure": ""
    },
    "failure": {
      "comp_success": ">=",
      "cnt_success": "0",
      "comp_failure": ">=",
      "cnt_failure": "1"
    }
  }
}
');
```

### Test results are NOT bound to a specific commit

Currently our human test results are not bound to a specific commit as the CI services like Travis or Scrutinizer are.
This means if a PR receives new commits, the test results would be automatically "invalidated" and testers would be required to submit their results again.

I believe this is good since it does not bother the testers when a PR receives only code style changes, on the other hand the code changes might require new tests.

So there are two solutions:

1. Whenever the PR gets new commits use the currently available test results for the latest commit and submit the results automatically to GitHub (currently implemented)
2. Make the test results bound to a specific commit as the other services. This would require testers to resubmit their test results whenever a PR gets new commits (to be implemented).
