### PR TITLE
Show the easy test option only if we have code.

### DIFF
--- a/templates/tracker/issue.edit.twig
+++ b/templates/tracker/issue.edit.twig
@@ -105,6 +105,7 @@
             <label for="build">{{ translate('Build') }}</label>
             <input name="item[build]" id="build" type="text" class="span1 validateBuild" value="{{ item.build }}" />
         </li>
+        {% if item.has_code %}
         <li>
             <label for="easy">{{ translate('Easy test') }}</label>
             <select name="item[easy]" id="easy" class="span1">
@@ -112,6 +113,7 @@
                 <option {{ 1 == item.easy ? "selected='selected'" : ""  }} value="1">{{ '1'|yesno }}</option>
             </select>
         </li>
+        {% endif %}
         {% if project.categories %}
         <li>
             {{ fields.label('categories[]', 'Categories'|_) }}


### PR DESCRIPTION
This PR let the easy test option only show if we have code.

I think there is no real need to mark a Issue as `easy test` as nothing is to test there.