### PR TITLE
Add the label that match to the current issue state (POC)

### DIFF
--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -124,7 +124,7 @@ class Save extends AbstractTrackerController
 			);
 
 			// Get the label that match the status
-			$label = $model->getStatusName($item->status);
+			$label = '~' . $model->getStatusName($item->status);
 
 			// Adding the label that match to the Status
 			$this->addLabelToGitHub($issueNumber, $label)

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -398,7 +398,7 @@ class Save extends AbstractTrackerController
 				else
 				{
 					$prefix = substr($label->name, 0, 1);
-	
+
 					if ($prefix == '~')
 					{
 						try

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -390,17 +390,6 @@ class Save extends AbstractTrackerController
 			{
 				if ($label->name == $new_label)
 				{
-					$application->enqueueMessage(
-						sprintf(
-							'GitHub item %s/%s #%d already has the %s label.',
-							$project->gh_user,
-							$project->gh_project,
-							$issueNumber,
-							$new_label
-						),
-						'error'
-					);
-
 					$LabelIsSet = true;
 				}
 
@@ -411,19 +400,10 @@ class Save extends AbstractTrackerController
 					try
 					{
 						$github->issues->labels->removeFromIssue(
-							$project->gh_user, $project->gh_project, $issueNumber, $label
-						);
-
-						// Post the new label on the object
-						$application->enqueueMessage(
-							sprintf(
-								'Removed %s label from %s/%s #%d',
-								$label,
-								$project->gh_user,
-								$project->gh_project,
-								$issueNumber
-							),
-							'success'
+							$project->gh_user,
+							$project->gh_project,
+							$issueNumber,
+							$label
 						);
 					}
 					catch (\DomainException $e)
@@ -455,7 +435,10 @@ class Save extends AbstractTrackerController
 			try
 			{
 				$github->issues->labels->add(
-					$project->gh_user, $project->gh_project, $issueNumber, $addLabels
+					$project->gh_user,
+					$project->gh_project,
+					$issueNumber,
+					$addLabels
 				);
 
 				// Post the new label on the object

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -395,32 +395,34 @@ class Save extends AbstractTrackerController
 				{
 					$LabelIsSet = true;
 				}
-
-				$prefix = substr($label->name, 0, 1);
-
-				if ($prefix == '~')
+				else
 				{
-					try
+					$prefix = substr($label->name, 0, 1);
+	
+					if ($prefix == '~')
 					{
-						$github->issues->labels->removeFromIssue(
-							$project->gh_user,
-							$project->gh_project,
-							$issueNumber,
-							$label
-						);
-					}
-					catch (\DomainException $e)
-					{
-						$application->enqueueMessage(
-							sprintf(
-								'Error remove label from GitHub pull request / issue %s/%s #%d - %s',
+						try
+						{
+							$github->issues->labels->removeFromIssue(
 								$project->gh_user,
 								$project->gh_project,
 								$issueNumber,
-								$e->getMessage()
-							),
-							'error'
-						);
+								$label
+							);
+						}
+						catch (\DomainException $e)
+						{
+							$application->enqueueMessage(
+								sprintf(
+									'Error remove label from GitHub pull request / issue %s/%s #%d - %s',
+									$project->gh_user,
+									$project->gh_project,
+									$issueNumber,
+									$e->getMessage()
+								),
+								'error'
+							);
+						}
 					}
 				}
 			}

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -362,6 +362,9 @@ class Save extends AbstractTrackerController
 		/* @type \JTracker\Application $application */
 		$application = $this->getContainer()->get('app');
 
+		$gitHub  = GithubFactory::getInstance($application);
+		$project = $application->getProject();
+
 		// Get the labels for the pull's issue
 		try
 		{

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -127,7 +127,7 @@ class Save extends AbstractTrackerController
 			$label = '~' . $model->getStatusName($item->status);
 
 			// Adding the label that match to the Status
-			$this->addLabelToGitHub($issueNumber, $label)
+			$this->addLabelToGitHub($issueNumber, $label);
 		}
 		else
 		{

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -359,6 +359,9 @@ class Save extends AbstractTrackerController
 	 */
 	private function addLabelToGitHub($issueNumber, $newlabel)
 	{
+		/* @type \JTracker\Application $application */
+		$application = $this->getContainer()->get('app');
+
 		// Get the labels for the pull's issue
 		try
 		{
@@ -366,15 +369,16 @@ class Save extends AbstractTrackerController
 		}
 		catch (\DomainException $e)
 		{
-			/*$logger->error(
+			$application->enqueueMessage(
 				sprintf(
 					'Error retrieving labels for GitHub item %s/%s #%d - %s',
 					$project->gh_user,
 					$project->gh_project,
 					$issueNumber,
 					$e->getMessage()
-				)
-			);*/
+				),
+				'error'
+			);
 
 			return;
 		}
@@ -386,15 +390,16 @@ class Save extends AbstractTrackerController
 			{
 				if ($label->name == $new_label)
 				{
-					/*$logger->info(
+					$application->enqueueMessage(
 						sprintf(
 							'GitHub item %s/%s #%d already has the %s label.',
 							$project->gh_user,
 							$project->gh_project,
 							$issueNumber,
 							$new_label
-						)
-					);*/
+						),
+						'error'
+					);
 
 					$LabelIsSet = true;
 				}
@@ -409,28 +414,30 @@ class Save extends AbstractTrackerController
 							$project->gh_user, $project->gh_project, $issueNumber, $label
 						);
 
-						/*// Post the new label on the object
-						$logger->info(
+						// Post the new label on the object
+						$application->enqueueMessage(
 							sprintf(
 								'Removed %s label from %s/%s #%d',
 								$label,
 								$project->gh_user,
 								$project->gh_project,
 								$issueNumber
-							)
-						);*/
+							),
+							'success'
+						);
 					}
 					catch (\DomainException $e)
 					{
-						/*$logger->error(
+						$application->enqueueMessage(
 							sprintf(
 								'Error remove label from GitHub pull request / issue %s/%s #%d - %s',
 								$project->gh_user,
 								$project->gh_project,
 								$issueNumber,
 								$e->getMessage()
-							)
-						);*/
+							),
+							'error'
+						);
 					}
 				}
 			}
@@ -451,28 +458,30 @@ class Save extends AbstractTrackerController
 					$project->gh_user, $project->gh_project, $issueNumber, $addLabels
 				);
 
-				/*// Post the new label on the object
-				$logger->info(
+				// Post the new label on the object
+				$application->enqueueMessage(
 					sprintf(
 						'Added %s labels to %s/%s #%d',
 						count($addLabels),
 						$project->gh_user,
 						$project->gh_project,
 						$issueNumber
-					)
-				);*/
+					),
+					'success'
+				);
 			}
 			catch (\DomainException $e)
 			{
-				/*$logger->error(
+				$application->enqueueMessage(
 					sprintf(
 						'Error adding labels to GitHub pull request %s/%s #%d - %s',
 						$project->gh_user,
 						$project->gh_project,
 						$issueNumber,
 						$e->getMessage()
-					)
-				);*/
+					),
+					'error'
+				);
 			}
 		}
 	}

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -397,9 +397,9 @@ class Save extends AbstractTrackerController
 
 					$LabelIsSet = true;
 				}
-				
+
 				$prefix = substr($label->name, 0, 1);
-				
+
 				if ($prefix == '~')
 				{
 					try

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -343,7 +343,8 @@ class Save extends AbstractTrackerController
 	/**
 	 * Add the status as label on GitHub.
 	 *
-	 * The method gets the list of current labels and remove all labels that starts with `~` as it is the status prefix, after this the method add the new status label
+	 * The method gets the list of current labels and remove all labels that starts with `~`
+	 * as it is the status prefix, after this the method add the new status label
 	 *
 	 * @param   integer  $issueNumber  The issue number.
 	 * @param   string   $newlabel     The new label that should be added as label.
@@ -408,8 +409,8 @@ class Save extends AbstractTrackerController
 							$project->gh_user, $project->gh_project, $issueNumber, $label
 						);
 
-						// Post the new label on the object
-						/*$logger->info(
+						/*// Post the new label on the object
+						$logger->info(
 							sprintf(
 								'Removed %s label from %s/%s #%d',
 								$label,
@@ -450,8 +451,8 @@ class Save extends AbstractTrackerController
 					$project->gh_user, $project->gh_project, $issueNumber, $addLabels
 				);
 
-				// Post the new label on the object
-				/*$logger->info(
+				/*// Post the new label on the object
+				$logger->info(
 					sprintf(
 						'Added %s labels to %s/%s #%d',
 						count($addLabels),
@@ -473,6 +474,6 @@ class Save extends AbstractTrackerController
 					)
 				);*/
 			}
-		}	
+		}
 	}
 }

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -391,7 +391,7 @@ class Save extends AbstractTrackerController
 		{
 			foreach ($labels as $label)
 			{
-				if ($label->name == $new_label)
+				if ($label->name == $newlabel)
 				{
 					$LabelIsSet = true;
 				}
@@ -431,7 +431,7 @@ class Save extends AbstractTrackerController
 		// Add the label if it isn't already set
 		if (!$LabelIsSet)
 		{
-			$addLabels[] = $new_label;
+			$addLabels[] = $newlabel;
 		}
 
 		// Only try to add labels if the array isn't empty

--- a/src/App/Tracker/Controller/Issue/Submit.php
+++ b/src/App/Tracker/Controller/Issue/Submit.php
@@ -112,7 +112,7 @@ class Submit extends AbstractTrackerController
 			$data['opened_by']      = $user->username;
 			$data['modified_by']    = $user->username;
 			$data['number']         = $issueModel->getNextNumber();
-			$data['description'] = $gitHub->markdown->render($body, 'markdown');
+			$data['description']    = $gitHub->markdown->render($body, 'markdown');
 		}
 
 		$data['priority']        = $application->input->getInt('priority');


### PR DESCRIPTION
Based on https://github.com/joomla/jissues/commit/08be5c5be7f612778c7930be96dde9eed925b7b9 this will add some code that do it generaly for all status that we have on jissues. This will run on every save action and add the status as label on github. (Ref https://github.com/joomla/jissues/issues/318)

I hope @b2z @mbabker or @elkuku can have a look into the code and the questions 

### Open questions

- do we need to create the label bevor adding it via the `$github->issues->labels->add(` function or will this done automatic?
- here: https://github.com/joomla/jissues/commit/08be5c5be7f612778c7930be96dde9eed925b7b9 we use some logger messages. How can i add a new logger instance or is this not needed?