### PR TITLE
Use the bot if it is defined

### DIFF
--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -362,7 +362,7 @@ class Save extends AbstractTrackerController
 		$project    = $application->getProject();
 		$labelIsSet = false;
 
-		// Using the but if it is configured
+		// Use the bot if it is configured
 		if ($project->getGh_Editbot_User() && $project->getGh_Editbot_Pass())
 		{
 			unset($gitHub);

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -362,6 +362,19 @@ class Save extends AbstractTrackerController
 		$project    = $application->getProject();
 		$labelIsSet = false;
 
+		// Using the but if it is configured
+		if ($project->getGh_Editbot_User() && $project->getGh_Editbot_Pass())
+		{
+			unset($gitHub);
+
+			$gitHub = GithubFactory::getInstance(
+				$application,
+				true,
+				$project->getGh_Editbot_User(),
+				$project->getGh_Editbot_Pass()
+			);
+		}
+
 		// Get the labels for the pull's issue
 		try
 		{


### PR DESCRIPTION
@b2z This implements the seccond note by @elkuku see here: https://github.com/joomla/jissues/pull/598#issuecomment-72524382

>Just a small side note(s).... [...] I guess you should use the defined edit bot credentials for the current project when instantiating the GitHub object.