### PR TITLE
Fix issue with help text for categories

### DIFF
--- a/templates/tracker/issue.add.twig
+++ b/templates/tracker/issue.add.twig
@@ -63,11 +63,10 @@
                 {% if project.categories %}
                 {{ fields.label('categories[]', 'Categories'|_) }}
                 {{ fields.selectCategories('categories[]', project.categories) }}
-                {% endif %}
-
                 <div class="helpText alert alert-info">
                     {{ "Please select one or more Categories here that match to your issue."|_ }}
                 </div>
+                {% endif %}
 
                 {% if user.check("edit") and project.milestones %}
                 {{ fields.label('milestone_id', 'Milestone'|_) }}


### PR DESCRIPTION
This PR fix a issue that i introduced here: https://github.com/joomla/jissues/pull/554

![category](https://cloud.githubusercontent.com/assets/2596554/6025141/6cbd33cc-abd0-11e4-88c9-60a111405d81.PNG)

So the help text is shown also if no categories are defined see here: http://issues.joomla.org/tracker/weblinks/add