### PR TITLE
Fix a notice when the repository has been deleted

### DIFF
--- a/cli/Application/Command/Get/Project/Issues.php
+++ b/cli/Application/Command/Get/Project/Issues.php
@@ -302,7 +302,11 @@ class Issues extends Project
 					$this->project->gh_user, $this->project->gh_project, $ghIssue->number
 				);
 
-				$table->pr_head_user = $pullRequest->head->user->login;
+				// If the $pullRequest->head->user object is not set, the repo/branch had been deleted by the user.
+				$table->pr_head_user = (isset($pullRequest->head->user))
+					? $pullRequest->head->user->login
+					: 'unknown_repository';
+
 				$table->pr_head_ref  = $pullRequest->head->ref;
 
 				$status = $this->GetMergeStatus($pullRequest);

--- a/templates/tracker/issue.index.twig
+++ b/templates/tracker/issue.index.twig
@@ -138,14 +138,22 @@
             {% endif %}
 
             {% if item.pr_head_ref %}
-                <li>
-                    &nbsp;
-                    <a href="https://github.com/{{ item.pr_head_user ~ '/'  ~ project.gh_project ~ '/archive/' ~ item.pr_head_ref ~ '.zip' }}"
-                       title="{{ 'Download this fork as a ZIP file'|_ }}">
+                {% if 'unknown_repository' == item.pr_head_user %}
+                    <li>
+                        &nbsp;
                         <span class="octicon octicon-repo-forked"></span>
-                        {{ item.pr_head_user ~ ':' ~ item.pr_head_ref }}
-                    </a>
-                </li>
+                        unknown repository
+                    </li>
+                {% else %}
+                    <li>
+                        &nbsp;
+                        <a href="https://github.com/{{ item.pr_head_user ~ '/'  ~ project.gh_project ~ '/archive/' ~ item.pr_head_ref ~ '.zip' }}"
+                           title="{{ 'Download this fork as a ZIP file'|_ }}">
+                            <span class="octicon octicon-repo-forked"></span>
+                            {{ item.pr_head_user ~ ':' ~ item.pr_head_ref }}
+                        </a>
+                    </li>
+                {% endif %}
             {% endif %}
 
         {% endif %}


### PR DESCRIPTION
This will prevent a PHP notice in our CLI script when the repo/branch had been deleted by the user.