### PR TITLE
Set build to branch default in hooks and sync

### DIFF
--- a/cli/Application/Command/Get/Project/Issues.php
+++ b/cli/Application/Command/Get/Project/Issues.php
@@ -290,6 +290,8 @@ class Issues extends Project
 				? $milestones[$ghIssue->milestone->number]
 				: null;
 
+			$table->build = $ghIssue->repository->default_branch;
+
 			// If the issue has a diff URL, it is a pull request.
 			if (isset($ghIssue->pull_request->diff_url))
 			{
@@ -301,6 +303,8 @@ class Issues extends Project
 				$pullRequest = $this->github->pulls->get(
 					$this->project->gh_user, $this->project->gh_project, $ghIssue->number
 				);
+
+				$table->build = $pullRequest->head->base->ref;
 
 				// If the $pullRequest->head->user object is not set, the repo/branch had been deleted by the user.
 				$table->pr_head_user = (isset($pullRequest->head->user))

--- a/src/App/Tracker/Controller/Hooks/ReceiveIssuesHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveIssuesHook.php
@@ -249,6 +249,11 @@ class ReceiveIssuesHook extends AbstractHookController
 		$data['rel_type']     = $table->rel_type;
 		$data['milestone_id'] = $table->milestone_id;
 
+		if (empty($table->build))
+		{
+			$data['build'] = $this->hookData->repository->default_branch;
+		}
+
 		$model = (new IssueModel($this->db))
 			->setProject(new TrackerProject($this->db, $this->project));
 

--- a/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
@@ -270,6 +270,11 @@ class ReceivePullsHook extends AbstractHookController
 		$data['rel_type']     = $table->rel_type;
 		$data['milestone_id'] = $table->milestone_id;
 
+		if (empty($table->build))
+		{
+			$data['build'] = $this->hookData->repository->default_branch;
+		}
+
 		$model = (new IssueModel($this->db))
 			->setProject(new TrackerProject($this->db, $this->project));
 


### PR DESCRIPTION
This PR will set the build to branch default:

1. On initial sync of the issue.
2. On hooks if the build is empty.

This is required because we require the build when issue is created on the tracker.