### PR TITLE
Let the RTC Label Check also run on a comment

### DIFF
--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -22,14 +22,13 @@ use Monolog\Logger;
 abstract class AbstractListener
 {
 	/**
-	 * Remove Labels
+	 * Check if label already exists
 	 *
-	 * @param   object       $hookData    Hook data payload
-	 * @param   Github       $github      Github object
-	 * @param   Logger       $logger      Logger object
-	 * @param   object       $project     Object containing project data
-	 * @param   IssuesTable  $table       Table object
-	 * @param   string       $checkLabel  The label to check
+	 * @param   object  $hookData    Hook data payload
+	 * @param   Github  $github      Github object
+	 * @param   Logger  $logger      Logger object
+	 * @param   object  $project     Object containing project data
+	 * @param   string  $checkLabel  The label to check
 	 *
 	 * @return  bool         True if the label already exists
 	 *
@@ -43,7 +42,7 @@ abstract class AbstractListener
 		// Get the labels for the pull's issue
 		try
 		{
-			$labels = $github->issues->get($project->gh_user, $project->gh_project, $issueNumber)->labels);
+			$labels = $github->issues->get($project->gh_user, $project->gh_project, $issueNumber)->labels;
 		}
 		catch (\DomainException $e)
 		{
@@ -79,12 +78,11 @@ abstract class AbstractListener
 	/**
 	 * Remove Labels
 	 *
-	 * @param   object       $hookData      Hook data payload
-	 * @param   Github       $github        Github object
-	 * @param   Logger       $logger        Logger object
-	 * @param   object       $project       Object containing project data
-	 * @param   IssuesTable  $table         Table object
-	 * @param   array        $removeLabels  The labels to remove
+	 * @param   object  $hookData      Hook data payload
+	 * @param   Github  $github        Github object
+	 * @param   Logger  $logger        Logger object
+	 * @param   object  $project       Object containing project data
+	 * @param   array   $removeLabels  The labels to remove
 	 *
 	 * @return  void
 	 *
@@ -160,12 +158,11 @@ abstract class AbstractListener
 	/**
 	 * Add Labels
 	 *
-	 * @param   object       $hookData   Hook data payload
-	 * @param   Github       $github     Github object
-	 * @param   Logger       $logger     Logger object
-	 * @param   object       $project    Object containing project data
-	 * @param   IssuesTable  $table      Table object
-	 * @param   array        $addLabels  The labels to add
+	 * @param   object  $hookData   Hook data payload
+	 * @param   Github  $github     Github object
+	 * @param   Logger  $logger     Logger object
+	 * @param   object  $project    Object containing project data
+	 * @param   array   $addLabels  The labels to add
 	 *
 	 * @return  void
 	 *

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -83,7 +83,7 @@ abstract class AbstractListener
 	/**
 	 * Get the correct issue ID if it is a Pull or Issue
 	 *
-	 * @param   object  $hookData   Hook data payload
+	 * @param   object  $hookData  Hook data payload
 	 *
 	 * @return  string  The Issue/Pull ID
 	 *

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Tracker Application
+ *
+ * @copyright  Copyright (C) 2012 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Tracker\Controller\Hooks\Listeners;
+
+use App\Tracker\Table\IssuesTable;
+use Joomla\Event\Event;
+use Joomla\Github\Github;
+
+use Monolog\Logger;
+
+/**
+ * Abstract listener class for custom Listeners
+ *
+ * @since  1.0
+ */
+abstract class AbstractListener
+{
+	/**
+	 * Remove Labels
+	 *
+	 * @param   object       $hookData      Hook data payload
+	 * @param   Github       $github        Github object
+	 * @param   Logger       $logger        Logger object
+	 * @param   object       $project       Object containing project data
+	 * @param   IssuesTable  $table         Table object
+	 * @param   array        $removeLabels  The labels to remove
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	protected function removeLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $removeLabels)
+	{
+		// The Github ID if we have a pull or issue so that method can handle both
+		$numberToUpdate = $this->getIssueID($hookData);
+
+		// Only try to remove labels if the array isn't empty
+		if (!empty($removeLabels))
+		{
+			// The foreach is needed as we have no array support on the `removeFromIssue` method
+			foreach ($removeLabels as $removeLabel)
+			{
+				try
+				{
+					$github->issues->labels->removeFromIssue(
+						$project->gh_user, $project->gh_project, $numberToUpdate, $removeLabel
+					);
+
+					// Post the new label on the object
+					$logger->info(
+						sprintf(
+							'Removed %s label to %s/%s #%d',
+							$removeLabel,
+							$project->gh_user,
+							$project->gh_project,
+							$numberToUpdate
+						)
+					);
+				}
+				catch (\DomainException $e)
+				{
+					$logger->error(
+						sprintf(
+							'Error removing the %s label from GitHub pull request %s/%s #%d - %s',
+							$removeLabel,
+							$project->gh_user,
+							$project->gh_project,
+							$numberToUpdate,
+							$e->getMessage()
+						)
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get the correct issue ID if it is a Pull or Issue
+	 *
+	 * @param   object  $hookData   Hook data payload
+	 *
+	 * @return  string  The Issue/Pull ID
+	 *
+	 * @since   1.0
+	 */
+	protected function getIssueId($hookData)
+	{
+		if (isset($hookData->pull_request->number)
+		{
+			return $hookData->pull_request->number;
+		}
+
+		if (isset($hookData->issue->number)
+		{
+			$numberToUpdate = $hookData->issue->number;
+		}
+	}
+
+	/**
+	 * Add Labels
+	 *
+	 * @param   object       $hookData   Hook data payload
+	 * @param   Github       $github     Github object
+	 * @param   Logger       $logger     Logger object
+	 * @param   object       $project    Object containing project data
+	 * @param   IssuesTable  $table      Table object
+	 * @param   array        $addLabels  The labels to add
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	protected function addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $addLabels)
+	{
+		// The Github ID if we have a pull or issue so that method can handle both
+		$numberToUpdate = $this->getIssueID($hookData);
+
+		// Only try to add labels if the array isn't empty
+		if (!empty($addLabels))
+		{
+			try
+			{
+				$github->issues->labels->add(
+					$project->gh_user, $project->gh_project, $numberToUpdate, $addLabels
+				);
+
+				// Post the new label on the object
+				$logger->info(
+					sprintf(
+						'Added %s labels to %s/%s #%d',
+						count($addLabels),
+						$project->gh_user,
+						$project->gh_project,
+						$numberToUpdate
+					)
+				);
+			}
+			catch (\DomainException $e)
+			{
+				$logger->error(
+					sprintf(
+						'Error adding labels to GitHub pull request %s/%s #%d - %s',
+						$project->gh_user,
+						$project->gh_project,
+						$numberToUpdate,
+						$e->getMessage()
+					)
+				);
+			}
+		}
+	}
+}

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -30,7 +30,7 @@ abstract class AbstractListener
 	 * @param   object  $project     Object containing project data
 	 * @param   string  $checkLabel  The label to check
 	 *
-	 * @return  bool         True if the label already exists
+	 * @return  bool    True if the label already exists
 	 *
 	 * @since   1.0
 	 */

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -37,6 +37,19 @@ abstract class AbstractListener
 		// The Github ID if we have a pull or issue so that method can handle both
 		$issueNumber = $this->getIssueNumber($hookData);
 
+		if ($issueNumber === null)
+		{
+			$logger->error(
+				sprintf(
+					'Error retrieving issue number for %s/%s',
+					$project->gh_user,
+					$project->gh_project
+				)
+			);
+
+			throw new RuntimeException;
+		}
+
 		// Get the labels for the pull's issue
 		try
 		{
@@ -91,6 +104,19 @@ abstract class AbstractListener
 		// The Github ID if we have a pull or issue so that method can handle both
 		$issueNumber = $this->getIssueNumber($hookData);
 
+		if ($issueNumber === null)
+		{
+			$logger->error(
+				sprintf(
+					'Error retrieving issue number for %s/%s',
+					$project->gh_user,
+					$project->gh_project
+				)
+			);
+
+			throw new RuntimeException;
+		}
+
 		// Only try to remove labels if the array isn't empty
 		if (!empty($removeLabels))
 		{
@@ -136,7 +162,7 @@ abstract class AbstractListener
 	 *
 	 * @param   object  $hookData  Hook data payload
 	 *
-	 * @return  mixed  The Issue number or null if no issue number found in hook data
+	 * @return  mixed The Issue number or null if no issue number found in hook data
 	 *
 	 * @since   1.0
 	 */
@@ -151,6 +177,8 @@ abstract class AbstractListener
 		{
 			return $hookData->issue->number;
 		}
+
+		return null;
 	}
 
 	/**
@@ -171,6 +199,19 @@ abstract class AbstractListener
 		// The Github ID if we have a pull or issue so that method can handle both
 		$issueNumber = $this->getIssueNumber($hookData);
 
+		if ($issueNumber === null)
+		{
+			$logger->error(
+				sprintf(
+					'Error retrieving issue number for %s/%s',
+					$project->gh_user,
+					$project->gh_project
+				)
+			);
+
+			throw new RuntimeException;
+		}
+		
 		// Only try to add labels if the array isn't empty
 		if (!empty($addLabels))
 		{

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -43,9 +43,7 @@ abstract class AbstractListener
 		// Get the labels for the pull's issue
 		try
 		{
-			$labels = $github->issues->get(
-				$project->gh_user, $project->gh_project, $issueNumber)->labels
-			);
+			$labels = $github->issues->get($project->gh_user, $project->gh_project, $issueNumber)->labels);
 		}
 		catch (\DomainException $e)
 		{
@@ -74,7 +72,7 @@ abstract class AbstractListener
 			}
 		}
 
-		// else return false
+		// Else return false
 		return false;
 	}
 

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -195,6 +195,8 @@ abstract class AbstractListener
 	 * @param   array   $addLabels  The labels to add
 	 *
 	 * @return  void
+	 *
+	 * @since   1.0
 	 * @throws  \RuntimeException
 	 *
 	 * @since   1.0

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -8,8 +8,6 @@
 
 namespace App\Tracker\Controller\Hooks\Listeners;
 
-use App\Tracker\Table\IssuesTable;
-use Joomla\Event\Event;
 use Joomla\Github\Github;
 
 use Monolog\Logger;
@@ -37,7 +35,7 @@ abstract class AbstractListener
 	protected function checkLabel($hookData, Github $github, Logger $logger, $project, $checkLabel)
 	{
 		// The Github ID if we have a pull or issue so that method can handle both
-		$issueNumber = $this->getIssueID($hookData);
+		$issueNumber = $this->getIssueNumber($hookData);
 
 		// Get the labels for the pull's issue
 		try
@@ -56,7 +54,7 @@ abstract class AbstractListener
 				)
 			);
 
-			return false;
+			throw new RuntimeException;
 		}
 
 		// Check if the label present that return true
@@ -91,7 +89,7 @@ abstract class AbstractListener
 	protected function removeLabels($hookData, Github $github, Logger $logger, $project, $removeLabels)
 	{
 		// The Github ID if we have a pull or issue so that method can handle both
-		$issueNumber = $this->getIssueID($hookData);
+		$issueNumber = $this->getIssueNumber($hookData);
 
 		// Only try to remove labels if the array isn't empty
 		if (!empty($removeLabels))
@@ -138,11 +136,11 @@ abstract class AbstractListener
 	 *
 	 * @param   object  $hookData  Hook data payload
 	 *
-	 * @return  string  The Issue/Pull ID
+	 * @return  mixed  The Issue number or null if no issue number found in hook data
 	 *
 	 * @since   1.0
 	 */
-	protected function getIssueId($hookData)
+	protected function getIssueNumber($hookData)
 	{
 		if (isset($hookData->pull_request->number))
 		{
@@ -171,7 +169,7 @@ abstract class AbstractListener
 	protected function addLabels($hookData, Github $github, Logger $logger, $project, $addLabels)
 	{
 		// The Github ID if we have a pull or issue so that method can handle both
-		$issueNumber = $this->getIssueID($hookData);
+		$issueNumber = $this->getIssueNumber($hookData);
 
 		// Only try to add labels if the array isn't empty
 		if (!empty($addLabels))

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -162,7 +162,7 @@ abstract class AbstractListener
 	 *
 	 * @param   object  $hookData  Hook data payload
 	 *
-	 * @return  mixed The Issue number or null if no issue number found in hook data
+	 * @return  mixed   The Issue number or null if no issue number found in hook data
 	 *
 	 * @since   1.0
 	 */
@@ -211,7 +211,7 @@ abstract class AbstractListener
 
 			throw new RuntimeException;
 		}
-		
+
 		// Only try to add labels if the array isn't empty
 		if (!empty($addLabels))
 		{

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -35,7 +35,7 @@ abstract class AbstractListener
 	 *
 	 * @since   1.0
 	 */
-	protected function checkLabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $checkLabel)
+	protected function checkLabel($hookData, Github $github, Logger $logger, $project, $checkLabel)
 	{
 		// The Github ID if we have a pull or issue so that method can handle both
 		$issueNumber = $this->getIssueID($hookData);
@@ -90,7 +90,7 @@ abstract class AbstractListener
 	 *
 	 * @since   1.0
 	 */
-	protected function removeLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $removeLabels)
+	protected function removeLabels($hookData, Github $github, Logger $logger, $project, $removeLabels)
 	{
 		// The Github ID if we have a pull or issue so that method can handle both
 		$issueNumber = $this->getIssueID($hookData);
@@ -146,12 +146,12 @@ abstract class AbstractListener
 	 */
 	protected function getIssueId($hookData)
 	{
-		if (isset($hookData->pull_request->number)
+		if (isset($hookData->pull_request->number))
 		{
 			return $hookData->pull_request->number;
 		}
 
-		if (isset($hookData->issue->number)
+		if (isset($hookData->issue->number))
 		{
 			return $hookData->issue->number;
 		}
@@ -171,7 +171,7 @@ abstract class AbstractListener
 	 *
 	 * @since   1.0
 	 */
-	protected function addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $addLabels)
+	protected function addLabels($hookData, Github $github, Logger $logger, $project, $addLabels)
 	{
 		// The Github ID if we have a pull or issue so that method can handle both
 		$issueNumber = $this->getIssueID($hookData);

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -31,6 +31,7 @@ abstract class AbstractListener
 	 * @return  bool    True if the label already exists
 	 *
 	 * @since   1.0
+	 * @throws  \RuntimeException
 	 */
 	protected function checkLabel($hookData, Github $github, Logger $logger, $project, $checkLabel)
 	{
@@ -47,7 +48,7 @@ abstract class AbstractListener
 				)
 			);
 
-			throw new RuntimeException;
+			throw new \RuntimeException('Error retrieving issue number for ' . $project->gh_user . '/' . $project->gh_project);
 		}
 
 		// Get the labels for the pull's issue
@@ -67,7 +68,7 @@ abstract class AbstractListener
 				)
 			);
 
-			throw new RuntimeException;
+			throw new \RuntimeException($e->getMessage(), 0, $e);
 		}
 
 		// Check if the label present that return true
@@ -98,6 +99,7 @@ abstract class AbstractListener
 	 * @return  void
 	 *
 	 * @since   1.0
+	 * @throws  \RuntimeException
 	 */
 	protected function removeLabels($hookData, Github $github, Logger $logger, $project, $removeLabels)
 	{
@@ -114,7 +116,7 @@ abstract class AbstractListener
 				)
 			);
 
-			throw new RuntimeException;
+			throw new \RuntimeException('Error retrieving issue number for ' . $project->gh_user . '/' . $project->gh_project);
 		}
 
 		// Only try to remove labels if the array isn't empty
@@ -152,6 +154,8 @@ abstract class AbstractListener
 							$e->getMessage()
 						)
 					);
+
+					throw new \RuntimeException($e->getMessage(), 0, $e);
 				}
 			}
 		}
@@ -191,6 +195,7 @@ abstract class AbstractListener
 	 * @param   array   $addLabels  The labels to add
 	 *
 	 * @return  void
+	 * @throws  \RuntimeException
 	 *
 	 * @since   1.0
 	 */
@@ -209,7 +214,7 @@ abstract class AbstractListener
 				)
 			);
 
-			throw new RuntimeException;
+			throw new \RuntimeException('Error retrieving issue number for ' . $project->gh_user . '/' . $project->gh_project);
 		}
 
 		// Only try to add labels if the array isn't empty
@@ -243,6 +248,8 @@ abstract class AbstractListener
 						$e->getMessage()
 					)
 				);
+
+				throw new \RuntimeException($e->getMessage(), 0, $e);
 			}
 		}
 	}

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -76,21 +76,21 @@ class JoomlacmsCommentsListener extends AbstractListener
 		// Set some data
 		$label      = 'RTC';
 		$labels     = array();
-		$labelIsSet = $this->checkLabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $label);
+		$labelIsSet = $this->checkLabel($hookData, Github $github, Logger $logger, $project, $label);
 
 		// Validation, if the status isn't RTC or the Label is set then go no further
 		if ($labelIsSet == true && $table->status != 4)
 		{
 			// Remove the RTC label as it isn't longer set to RTC
 			$labels[] = $label;
-			$this->removeLabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $labels);
+			$this->removeLabel($hookData, Github $github, Logger $logger, $project, $labels);
 		}
 
 		if ($labelIsSet == false && $table->status == 4)
 		{
 			// Add the RTC label as it isn't already set
 			$labels[] = $label;
-			$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $labels);
+			$this->addLabels($hookData, Github $github, Logger $logger, $project, $labels);
 		}
 	}
 }

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -20,7 +20,7 @@ use Monolog\Logger;
  *
  * @since  1.0
  */
-class JoomlacmsCommentsListener
+class JoomlacmsCommentsListener extends AbstractListener
 {
 	/**
 	 * Event for after Comments gets added to the Tracker

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -9,7 +9,7 @@
 namespace App\Tracker\Controller\Hooks\Listeners;
 
 use App\Tracker\Table\IssuesTable;
-
+use App\Tracker\Controller\Hooks\Listeners\AbstractListener;
 use Joomla\Event\Event;
 use Joomla\Github\Github;
 

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -31,7 +31,7 @@ class JoomlacmsCommentsListener
 	 *
 	 * @since   1.0
 	 */
-	public function onCommentAfterAddingComment(Event $event)
+	public function onCommentAfterCreate(Event $event)
 	{
 		// Pull the arguments array
 		$arguments = $event->getArguments();

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -69,7 +69,7 @@ class JoomlacmsCommentsListener
 		// Get the labels for the pull's issue
 		try
 		{
-			$labels = $github->issues->get($project->gh_user, $project->gh_project, $hookData->pull_request->number)->labels;
+			$labels = $github->issues->get($project->gh_user, $project->gh_project, $hookData->issue->number)->labels;
 		}
 		catch (\DomainException $e)
 		{
@@ -78,7 +78,7 @@ class JoomlacmsCommentsListener
 					'Error retrieving labels for GitHub item %s/%s #%d - %s',
 					$project->gh_user,
 					$project->gh_project,
-					$hookData->pull_request->number,
+					$hookData->issue->number,
 					$e->getMessage()
 				)
 			);
@@ -98,7 +98,7 @@ class JoomlacmsCommentsListener
 							'GitHub item %s/%s #%d already has the %s label.',
 							$project->gh_user,
 							$project->gh_project,
-							$hookData->pull_request->number,
+							$hookData->issue->number,
 							$RTClabel
 						)
 					);
@@ -120,7 +120,7 @@ class JoomlacmsCommentsListener
 			try
 			{
 				$github->issues->labels->add(
-					$project->gh_user, $project->gh_project, $hookData->pull_request->number, $addLabels
+					$project->gh_user, $project->gh_project, $hookData->issue->number, $addLabels
 				);
 
 				// Post the new label on the object
@@ -130,7 +130,7 @@ class JoomlacmsCommentsListener
 						count($addLabels),
 						$project->gh_user,
 						$project->gh_project,
-						$hookData->pull_request->number
+						$hookData->issue->number
 					)
 				);
 			}
@@ -141,7 +141,7 @@ class JoomlacmsCommentsListener
 						'Error adding labels to GitHub pull request %s/%s #%d - %s',
 						$project->gh_user,
 						$project->gh_project,
-						$hookData->pull_request->number,
+						$hookData->issue->number,
 						$e->getMessage()
 					)
 				);

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -37,7 +37,7 @@ class JoomlacmsCommentsListener extends AbstractListener
 		$arguments = $event->getArguments();
 
 		// Add a RTC label if the item is in that status
-		$this->addRTClabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
+		$this->checkRTClabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
 	}
 
 	/**

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -23,6 +23,24 @@ use Monolog\Logger;
 class JoomlacmsCommentsListener
 {
 	/**
+	 * Event for after Comments gets added to the Tracker
+	 *
+	 * @param   Event  $event  Event object
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function onCommentAfterAddingComment(Event $event)
+	{
+		// Pull the arguments array
+		$arguments = $event->getArguments();
+
+		// Add a RTC label if the item is in that status
+		$this->addRTClabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
+	}
+
+	/**
 	 * Event for after Comments requests are updated in the application
 	 *
 	 * @param   Event  $event  Event object

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -63,10 +63,11 @@ class JoomlacmsCommentsListener extends AbstractListener
 	/**
 	 * Adds a "No Code Attached Yet" label
 	 *
-	 * @param   object  $hookData  Hook data payload
-	 * @param   Github  $github    Github object
-	 * @param   Logger  $logger    Logger object
-	 * @param   object  $project   Object containing project data
+	 * @param   object       $hookData  Hook data payload
+	 * @param   Github       $github    Github object
+	 * @param   Logger       $logger    Logger object
+	 * @param   object       $project   Object containing project data
+	 * @param   IssuesTable  $table     Table object
 	 *
 	 * @return  void
 	 *
@@ -85,6 +86,7 @@ class JoomlacmsCommentsListener extends AbstractListener
 			$labels[] = $label;
 			$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $labels);
 		}
+	}
 
 	/**
 	 * Checks for the RTC label

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -22,7 +22,6 @@ use Monolog\Logger;
  */
 class JoomlacmsCommentsListener
 {
-
 	/**
 	 * Event for after Comments requests are updated in the application
 	 *

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -80,7 +80,7 @@ class JoomlacmsCommentsListener
 		// Get the labels for the pull's issue
 		try
 		{
-			$labels = $github->issues->get($project->gh_user, $project->gh_project, $hookData->pull_request->number)->labels;
+			$labels = $github->issues->get($project->gh_user, $project->gh_project, $hookData->issue->number)->labels;
 		}
 		catch (\DomainException $e)
 		{
@@ -89,7 +89,7 @@ class JoomlacmsCommentsListener
 					'Error retrieving labels for GitHub item %s/%s #%d - %s',
 					$project->gh_user,
 					$project->gh_project,
-					$hookData->pull_request->number,
+					$hookData->issue->number,
 					$e->getMessage()
 				)
 			);
@@ -109,7 +109,7 @@ class JoomlacmsCommentsListener
 							'GitHub item %s/%s #%d already has the %s label.',
 							$project->gh_user,
 							$project->gh_project,
-							$hookData->pull_request->number,
+							$hookData->issue->number,
 							$RTClabel
 						)
 					);
@@ -123,8 +123,8 @@ class JoomlacmsCommentsListener
 		if ($rtcLabelSet == true && $table->status != 4)
 		{
 			// Remove the RTC label as it isn't longer set to RTC
-			$removeLabels = array();
-			$removeLabels = 'RTC';
+			$removeLabels   = array();
+			$removeLabels[] = 'RTC';
 			$this->removeLabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $removeLabels);
 
 			return;

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Tracker Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Tracker\Controller\Hooks\Listeners;
+
+use App\Tracker\Table\IssuesTable;
+
+use Joomla\Event\Event;
+use Joomla\Github\Github;
+
+use Monolog\Logger;
+
+/**
+ * Event listener for the joomla-cms Comments request hook
+ *
+ * @since  1.0
+ */
+class JoomlacmsCommentsListener
+{
+
+	/**
+	 * Event for after Comments requests are updated in the application
+	 *
+	 * @param   Event  $event  Event object
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function onCommentAfterUpdate(Event $event)
+	{
+		// Pull the arguments array
+		$arguments = $event->getArguments();
+
+		// Add a RTC label if the item is in that status
+		$this->addRTClabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
+	}
+
+	/**
+	 * Adds a RTC label
+	 *
+	 * @param   object       $hookData  Hook data payload
+	 * @param   Github       $github    Github object
+	 * @param   Logger       $logger    Logger object
+	 * @param   object       $project   Object containing project data
+	 * @param   IssuesTable  $table     Table object
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	protected function addRTClabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table)
+	{
+		// Validation, if the status isn't RTC then go no further
+		if ($table->status != 4)
+		{
+			return;
+		}
+
+		// Set some data
+		$RTClabel    = 'RTC';
+		$addLabels   = array();
+		$rtcLabelSet = false;
+
+		// Get the labels for the pull's issue
+		try
+		{
+			$labels = $github->issues->get($project->gh_user, $project->gh_project, $hookData->pull_request->number)->labels;
+		}
+		catch (\DomainException $e)
+		{
+			$logger->error(
+				sprintf(
+					'Error retrieving labels for GitHub item %s/%s #%d - %s',
+					$project->gh_user,
+					$project->gh_project,
+					$hookData->pull_request->number,
+					$e->getMessage()
+				)
+			);
+
+			return;
+		}
+
+		// Check if the PR- label present if there are already labels attached to the item
+		if (count($labels) > 0)
+		{
+			foreach ($labels as $label)
+			{
+				if (!$rtcLabelSet && $label->name == $RTClabel)
+				{
+					$logger->info(
+						sprintf(
+							'GitHub item %s/%s #%d already has the %s label.',
+							$project->gh_user,
+							$project->gh_project,
+							$hookData->pull_request->number,
+							$RTClabel
+						)
+					);
+
+					$rtcLabelSet = true;
+				}
+			}
+		}
+
+		// Add the RTC label if it isn't already set
+		if (!$rtcLabelSet)
+		{
+			$addLabels[] = $RTClabel;
+		}
+
+		// Only try to add labels if the array isn't empty
+		if (!empty($addLabels))
+		{
+			try
+			{
+				$github->issues->labels->add(
+					$project->gh_user, $project->gh_project, $hookData->pull_request->number, $addLabels
+				);
+
+				// Post the new label on the object
+				$logger->info(
+					sprintf(
+						'Added %s labels to %s/%s #%d',
+						count($addLabels),
+						$project->gh_user,
+						$project->gh_project,
+						$hookData->pull_request->number
+					)
+				);
+			}
+			catch (\DomainException $e)
+			{
+				$logger->error(
+					sprintf(
+						'Error adding labels to GitHub pull request %s/%s #%d - %s',
+						$project->gh_user,
+						$project->gh_project,
+						$hookData->pull_request->number,
+						$e->getMessage()
+					)
+				);
+			}
+		}
+	}
+}

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -54,38 +54,8 @@ class JoomlacmsCommentsListener extends AbstractListener
 		// Pull the arguments array
 		$arguments = $event->getArguments();
 
-		$this->checkNoCodelabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
-
 		// Add a RTC label if the item is in that status
 		$this->checkRTClabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
-	}
-
-	/**
-	 * Adds a "No Code Attached Yet" label
-	 *
-	 * @param   object       $hookData  Hook data payload
-	 * @param   Github       $github    Github object
-	 * @param   Logger       $logger    Logger object
-	 * @param   object       $project   Object containing project data
-	 * @param   IssuesTable  $table     Table object
-	 *
-	 * @return  void
-	 *
-	 * @since   1.0
-	 */
-	protected function checkNoCodelabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table)
-	{
-		// Set some data
-		$label      = 'No Code Attached Yet';
-		$labels     = array();
-		$labelIsSet = $this->checkLabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $label);
-
-		if ($labelIsSet == false)
-		{
-			// Add the RTC label as it isn't already set
-			$labels[] = $label;
-			$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $labels);
-		}
 	}
 
 	/**

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -9,7 +9,6 @@
 namespace App\Tracker\Controller\Hooks\Listeners;
 
 use App\Tracker\Table\IssuesTable;
-use App\Tracker\Controller\Hooks\Listeners\AbstractListener;
 use Joomla\Event\Event;
 use Joomla\Github\Github;
 
@@ -76,21 +75,21 @@ class JoomlacmsCommentsListener extends AbstractListener
 		// Set some data
 		$label      = 'RTC';
 		$labels     = array();
-		$labelIsSet = $this->checkLabel($hookData, Github $github, Logger $logger, $project, $label);
+		$labelIsSet = $this->checkLabel($hookData, $github, $logger, $project, $label);
 
 		// Validation, if the status isn't RTC or the Label is set then go no further
 		if ($labelIsSet == true && $table->status != 4)
 		{
 			// Remove the RTC label as it isn't longer set to RTC
 			$labels[] = $label;
-			$this->removeLabel($hookData, Github $github, Logger $logger, $project, $labels);
+			$this->removeLabel($hookData, $github, $logger, $project, $labels);
 		}
 
 		if ($labelIsSet == false && $table->status == 4)
 		{
 			// Add the RTC label as it isn't already set
 			$labels[] = $label;
-			$this->addLabels($hookData, Github $github, Logger $logger, $project, $labels);
+			$this->addLabels($hookData, $github, $logger, $project, $labels);
 		}
 	}
 }

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -126,15 +126,14 @@ class JoomlacmsCommentsListener extends AbstractListener
 			$removeLabels   = array();
 			$removeLabels[] = 'RTC';
 			$this->removeLabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $removeLabels);
-
-			return;
 		}
 
-		// Add the RTC label as it isn't already set
-		$addLabels   = array();
-		$addLabels[] = 'RTC';
-		$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $addLabels);
-
-		return;
+		if ($rtcLabelSet == false && $table->status == 4)
+		{
+			// Add the RTC label as it isn't already set
+			$addLabels   = array();
+			$addLabels[] = 'RTC';
+			$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $addLabels);
+		}
 	}
 }

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -82,7 +82,7 @@ class JoomlacmsCommentsListener extends AbstractListener
 		{
 			// Remove the RTC label as it isn't longer set to RTC
 			$labels[] = $label;
-			$this->removeLabel($hookData, $github, $logger, $project, $labels);
+			$this->removeLabels($hookData, $github, $logger, $project, $labels);
 		}
 
 		if ($labelIsSet == false && $table->status == 4)

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
@@ -8,6 +8,7 @@
 
 namespace App\Tracker\Controller\Hooks\Listeners;
 
+use App\Tracker\Controller\Hooks\Listeners\AbstractListener;
 use Joomla\Event\Event;
 use Joomla\Github\Github;
 

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
@@ -46,11 +46,10 @@ class JoomlacmsIssuesListener extends AbstractListener
 	/**
 	 * Adds a "No Code Attached Yet" label
 	 *
-	 * @param   object       $hookData  Hook data payload
-	 * @param   Github       $github    Github object
-	 * @param   Logger       $logger    Logger object
-	 * @param   object       $project   Object containing project data
-	 * @param   IssuesTable  $table     Table object
+	 * @param   object   $hookData  Hook data payload
+	 * @param   Github   $github    Github object
+	 * @param   Logger   $logger    Logger object
+	 * @param   object   $project   Object containing project data
 	 *
 	 * @return  void
 	 *

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
@@ -18,7 +18,7 @@ use Monolog\Logger;
  *
  * @since  1.0
  */
-class JoomlacmsIssuesListener
+class JoomlacmsIssuesListener extends AbstractListener
 {
 	/**
 	 * Event for after issues are created in the application

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
@@ -39,7 +39,7 @@ class JoomlacmsIssuesListener extends AbstractListener
 		if ($arguments['action'] === 'opened')
 		{
 			// Add a "no code" label
-			$this->checkNoCodelabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
+			$this->checkNoCodelabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project']);
 		}
 	}
 
@@ -56,18 +56,18 @@ class JoomlacmsIssuesListener extends AbstractListener
 	 *
 	 * @since   1.0
 	 */
-	protected function checkNoCodelabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table)
+	protected function checkNoCodelabel($hookData, Github $github, Logger $logger, $project)
 	{
 		// Set some data
 		$label      = 'No Code Attached Yet';
 		$labels     = array();
-		$labelIsSet = $this->checkLabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $label);
+		$labelIsSet = $this->checkLabel($hookData, $github, $logger, $project, $label);
 
 		if ($labelIsSet == false)
 		{
 			// Add the label as it isn't already set
 			$labels[] = $label;
-			$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $labels);
+			$this->addLabels($hookData, $github, $logger, $project, $labels);
 		}
 	}
 }

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
@@ -46,10 +46,11 @@ class JoomlacmsIssuesListener extends AbstractListener
 	/**
 	 * Adds a "No Code Attached Yet" label
 	 *
-	 * @param   object  $hookData  Hook data payload
-	 * @param   Github  $github    Github object
-	 * @param   Logger  $logger    Logger object
-	 * @param   object  $project   Object containing project data
+	 * @param   object       $hookData  Hook data payload
+	 * @param   Github       $github    Github object
+	 * @param   Logger       $logger    Logger object
+	 * @param   object       $project   Object containing project data
+	 * @param   IssuesTable  $table     Table object
 	 *
 	 * @return  void
 	 *
@@ -64,7 +65,7 @@ class JoomlacmsIssuesListener extends AbstractListener
 
 		if ($labelIsSet == false)
 		{
-			// Add the RTC label as it isn't already set
+			// Add the label as it isn't already set
 			$labels[] = $label;
 			$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $labels);
 		}

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
@@ -8,7 +8,6 @@
 
 namespace App\Tracker\Controller\Hooks\Listeners;
 
-use App\Tracker\Controller\Hooks\Listeners\AbstractListener;
 use Joomla\Event\Event;
 use Joomla\Github\Github;
 

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
@@ -46,10 +46,10 @@ class JoomlacmsIssuesListener extends AbstractListener
 	/**
 	 * Adds a "No Code Attached Yet" label
 	 *
-	 * @param   object   $hookData  Hook data payload
-	 * @param   Github   $github    Github object
-	 * @param   Logger   $logger    Logger object
-	 * @param   object   $project   Object containing project data
+	 * @param   object  $hookData  Hook data payload
+	 * @param   Github  $github    Github object
+	 * @param   Logger  $logger    Logger object
+	 * @param   object  $project   Object containing project data
 	 *
 	 * @return  void
 	 *

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
@@ -39,7 +39,7 @@ class JoomlacmsIssuesListener extends AbstractListener
 		if ($arguments['action'] === 'opened')
 		{
 			// Add a "no code" label
-			$this->checkNoCodelabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project']);
+			$this->checkNoCodelabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
 		}
 	}
 
@@ -55,60 +55,18 @@ class JoomlacmsIssuesListener extends AbstractListener
 	 *
 	 * @since   1.0
 	 */
-	protected function checkNoCodelabel($hookData, Github $github, Logger $logger, $project)
+	protected function checkNoCodelabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table)
 	{
 		// Set some data
-		$codeLabel    = 'No Code Attached Yet';
-		$codeLabelSet = false;
+		$label      = 'No Code Attached Yet';
+		$labels     = array();
+		$labelIsSet = $this->checkLabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $label);
 
-		// Get the labels for the issue
-		try
+		if ($labelIsSet == false)
 		{
-			$labels = $github->issues->get($project->gh_user, $project->gh_project, $hookData->issue->number)->labels;
-		}
-		catch (\DomainException $e)
-		{
-			$logger->error(
-				sprintf(
-					'Error retrieving labels for GitHub item %s/%s #%d - %s',
-					$project->gh_user,
-					$project->gh_project,
-					$hookData->issue->number,
-					$e->getMessage()
-				)
-			);
-
-			return;
-		}
-
-		// Check if the label is present only if there are already labels attached to the item
-		if (count($labels) > 0)
-		{
-			foreach ($labels as $label)
-			{
-				if (!$codeLabelSet && $label->name == $codeLabel)
-				{
-					$logger->info(
-						sprintf(
-							'GitHub item %s/%s #%d already has the %s label.',
-							$project->gh_user,
-							$project->gh_project,
-							$hookData->issue->number,
-							$codeLabel
-						)
-					);
-
-					$codeLabelSet = true;
-				}
-			}
-		}
-
-		// Add the label if it isn't already set
-		if (!$codeLabelSet)
-		{
-			$addLabels   = array();
-			$addLabels[] = $codeLabel;
-			$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $addLabels);
+			// Add the RTC label as it isn't already set
+			$labels[] = $label;
+			$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $labels);
 		}
 	}
 }

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
@@ -38,7 +38,7 @@ class JoomlacmsIssuesListener
 		if ($arguments['action'] === 'opened')
 		{
 			// Add a "no code" label
-			$this->addCodelabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project']);
+			$this->checkNoCodelabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project']);
 		}
 	}
 
@@ -54,11 +54,10 @@ class JoomlacmsIssuesListener
 	 *
 	 * @since   1.0
 	 */
-	protected function addCodelabel($hookData, Github $github, Logger $logger, $project)
+	protected function checkNoCodelabel($hookData, Github $github, Logger $logger, $project)
 	{
 		// Set some data
 		$codeLabel    = 'No Code Attached Yet';
-		$addLabels    = array();
 		$codeLabelSet = false;
 
 		// Get the labels for the issue
@@ -106,41 +105,9 @@ class JoomlacmsIssuesListener
 		// Add the label if it isn't already set
 		if (!$codeLabelSet)
 		{
+			$addLabels   = array();
 			$addLabels[] = $codeLabel;
-		}
-
-		// Only try to add labels if the array isn't empty
-		if (!empty($addLabels))
-		{
-			try
-			{
-				$github->issues->labels->add(
-					$project->gh_user, $project->gh_project, $hookData->issue->number, $addLabels
-				);
-
-				// Post the new label on the object
-				$logger->info(
-					sprintf(
-						'Added %s labels to %s/%s #%d',
-						count($addLabels),
-						$project->gh_user,
-						$project->gh_project,
-						$hookData->issue->number
-					)
-				);
-			}
-			catch (\DomainException $e)
-			{
-				$logger->error(
-					sprintf(
-						'Error adding labels to GitHub issue %s/%s #%d - %s',
-						$project->gh_user,
-						$project->gh_project,
-						$hookData->issue->number,
-						$e->getMessage()
-					)
-				);
-			}
+			$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $addLabels);
 		}
 	}
 }

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -145,8 +145,8 @@ class JoomlacmsPullsListener extends AbstractListener
 		if ($rtcLabelSet == true && $table->status != 4)
 		{
 			// Remove the RTC label as it isn't longer set to RTC
-			$removeLabels = array();
-			$removeLabels = 'RTC';
+			$removeLabels   = array();
+			$removeLabels[] = 'RTC';
 			$this->removeLabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $removeLabels);
 
 			return;

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -40,7 +40,7 @@ class JoomlacmsPullsListener extends AbstractListener
 		if ($arguments['action'] === 'opened')
 		{
 			// Check that pull requests have certain labels
-			$this->checkPullLabels($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
+			$this->checkPullLabels($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project']);
 
 			// Check if the pull request targets the master branch
 			$this->checkMasterBranch($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project']);
@@ -71,7 +71,7 @@ class JoomlacmsPullsListener extends AbstractListener
 		$arguments = $event->getArguments();
 
 		// Check that pull requests have certain labels
-		$this->checkPullLabels($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
+		$this->checkPullLabels($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project']);
 
 		// Place the JoomlaCode ID in the issue title if it isn't already there
 		$this->updatePullTitle($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
@@ -266,13 +266,12 @@ class JoomlacmsPullsListener extends AbstractListener
 	 * @param   Github       $github    Github object
 	 * @param   Logger       $logger    Logger object
 	 * @param   object       $project   Object containing project data
-	 * @param   IssuesTable  $table     Table object
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
 	 */
-	protected function checkPullLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table)
+	protected function checkPullLabels($hookData, Github $github, Logger $logger, $project)
 	{
 		// Set some data
 		$prLabel        = 'PR-' . $hookData->pull_request->base->ref;
@@ -366,6 +365,11 @@ class JoomlacmsPullsListener extends AbstractListener
 	 */
 	protected function setPending(Logger $logger, $project, IssuesTable $table)
 	{
+		if ($table->status == 3)
+		{
+			return;
+		}
+
 		// Reset the issue status to pending and try updating the database
 		try
 		{

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -262,10 +262,11 @@ class JoomlacmsPullsListener extends AbstractListener
 	/**
 	 * Checks for a PR-<branch> label
 	 *
-	 * @param   object  $hookData  Hook data payload
-	 * @param   Github  $github    Github object
-	 * @param   Logger  $logger    Logger object
-	 * @param   object  $project   Object containing project data
+	 * @param   object       $hookData  Hook data payload
+	 * @param   Github       $github    Github object
+	 * @param   Logger       $logger    Logger object
+	 * @param   object       $project   Object containing project data
+	 * @param   IssuesTable  $table     Table object
 	 *
 	 * @return  void
 	 *
@@ -288,22 +289,16 @@ class JoomlacmsPullsListener extends AbstractListener
 			$addLabels[] = $prLabel;
 		}
 
-		if ($languageChange)
+		if ($languageChange && !$languageLabelSet)
 		{
-			if (!$languageLabelSet)
-			{
-				$addLabels[] = $languageLabel;
-			}
-		else
-		{
-			if ($languageLabelSet)
-			{
-				$removeLabels[] = $languageLabel;
-				$this->removeLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $removeLabels)
-			}
+			$addLabels[] = $languageLabel;
+			$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $addLabels);
 		}
-
-		$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $addLabels);
+		elseif ($languageLabelSet)
+		{
+			$removeLabels[] = $languageLabel;
+			$this->removeLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $removeLabels)
+		}
 
 		return;
 	}
@@ -332,9 +327,6 @@ class JoomlacmsPullsListener extends AbstractListener
 				}
 			}
 		}
-
-		return false;
-	}
 
 		return false;
 	}

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -311,11 +311,22 @@ class JoomlacmsPullsListener extends AbstractListener
 		if ($languageChange && !$languageLabelSet)
 		{
 			$addLabels[] = $languageLabel;
-			$this->addLabels($hookData, $github, $logger, $project, $addLabels);
 		}
 		elseif ($languageLabelSet)
 		{
 			$removeLabels[] = $languageLabel;
+			$this->removeLabels($hookData, $github, $logger, $project, $removeLabels);
+		}
+
+		// Add the labels if we need
+		if (!empty($addLabels))
+		{
+			$this->addLabels($hookData, $github, $logger, $project, $addLabels);
+		}
+
+		// Remove the labels if we need
+		if (!empty($removeLabels))
+		{
 			$this->removeLabels($hookData, $github, $logger, $project, $removeLabels);
 		}
 

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -9,7 +9,6 @@
 namespace App\Tracker\Controller\Hooks\Listeners;
 
 use App\Tracker\Table\IssuesTable;
-use App\Tracker\Controller\Hooks\Listeners\AbstractListener;
 use Joomla\Event\Event;
 use Joomla\Github\Github;
 
@@ -105,7 +104,7 @@ class JoomlacmsPullsListener extends AbstractListener
 		{
 			// Remove the RTC label as it isn't longer set to RTC
 			$labels[] = $label;
-			$this->removeLabel($hookData, $github, $logger, $project, $labels);
+			$this->removeLabels($hookData, $github, $logger, $project, $labels);
 		}
 
 		if ($labelIsSet == false && $table->status == 4)
@@ -317,7 +316,7 @@ class JoomlacmsPullsListener extends AbstractListener
 		elseif ($languageLabelSet)
 		{
 			$removeLabels[] = $languageLabel;
-			$this->removeLabels($hookData, $github, $logger, $project, $removeLabels)
+			$this->removeLabels($hookData, $github, $logger, $project, $removeLabels);
 		}
 
 		return;

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -262,10 +262,10 @@ class JoomlacmsPullsListener extends AbstractListener
 	/**
 	 * Checks for a PR-<branch> label
 	 *
-	 * @param   object       $hookData  Hook data payload
-	 * @param   Github       $github    Github object
-	 * @param   Logger       $logger    Logger object
-	 * @param   object       $project   Object containing project data
+	 * @param   object  $hookData  Hook data payload
+	 * @param   Github  $github    Github object
+	 * @param   Logger  $logger    Logger object
+	 * @param   object  $project   Object containing project data
 	 *
 	 * @return  void
 	 *
@@ -309,7 +309,6 @@ class JoomlacmsPullsListener extends AbstractListener
 		$languageChange   = $this->checkLanguageChange($files);
 		$languageLabelSet = $this->checkLabel($hookData, $github, $logger, $project, $languageLabel);
 
-		
 		if ($languageChange && !$languageLabelSet)
 		{
 			$addLabels[] = $languageLabel;

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -148,16 +148,15 @@ class JoomlacmsPullsListener extends AbstractListener
 			$removeLabels   = array();
 			$removeLabels[] = 'RTC';
 			$this->removeLabel($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $removeLabels);
-
-			return;
 		}
 
-		// Add the RTC label as it isn't already set
-		$addLabels   = array();
-		$addLabels[] = 'RTC';
-		$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $addLabels);
-
-		return;
+		if ($rtcLabelSet == false && $table->status == 4)
+		{
+			// Add the RTC label as it isn't already set
+			$addLabels   = array();
+			$addLabels[] = 'RTC';
+			$this->addLabels($hookData, Github $github, Logger $logger, $project, IssuesTable $table, $addLabels);
+		}
 	}
 
 	/**

--- a/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
@@ -284,7 +284,18 @@ class ReceiveCommentsHook extends AbstractHookController
 			$this->getContainer()->get('app')->close();
 		}
 
-		$issuetable = new IssuesTable($this->db);
+		try
+		{
+			$issuetable = new IssuesTable($this->db);
+			$issuetable->load(array('issue_number' => $id));
+		}
+		catch (\Exception $e)
+		{
+			$this->logger->error(
+				'Error loading the database for comment ' . $id . ':' . $e->getMessage()
+			);
+		}
+
 		$this->triggerEvent('onCommentAfterUpdate', $issuetable);
 
 		// Store was successful, update status

--- a/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
@@ -132,9 +132,14 @@ class ReceiveCommentsHook extends AbstractHookController
 		{
 			// Get a table object for the new record to process in the event listeners
 			$issuetable = new IssuesTable($this->db);
-			$issuetable->load(array('issue_number' => $this->hookData->issue->number));
+			$issueTable->load(
+			    array(
+			        'issue_number' => $this->hookData->issue->number,
+			        'project_id'   => $this->project->project_id,
+			    )
+			);
 
-			$this->triggerEvent('onCommentAfterCreate', $issuetable);
+			$this->triggerEvent('onCommentAfterCreate', $issueTable);
 		}
 		catch (\Exception $e)
 		{
@@ -301,9 +306,15 @@ class ReceiveCommentsHook extends AbstractHookController
 
 		try
 		{
-			$issuetable = new IssuesTable($this->db);
-			$issuetable->load(array('issue_number' => $this->hookData->issue->number));
-			$this->triggerEvent('onCommentAfterUpdate', $issuetable);
+			$issueTable = new IssuesTable($this->db);
+			$issueTable->load(
+			    array(
+			        'issue_number' => $this->hookData->issue->number,
+			        'project_id'   => $this->project->project_id,
+			    )
+			);
+
+			$this->triggerEvent('onCommentAfterUpdate', $issueTable);
 		}
 		catch (\Exception $e)
 		{

--- a/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
@@ -284,7 +284,8 @@ class ReceiveCommentsHook extends AbstractHookController
 			$this->getContainer()->get('app')->close();
 		}
 
-		$this->triggerEvent('onCommentAfterUpdate', $table);
+		$issuetable = new IssuesTable($this->db);
+		$this->triggerEvent('onCommentAfterUpdate', $issuetable);
 
 		// Store was successful, update status
 		$this->logger->info(

--- a/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
@@ -133,10 +133,10 @@ class ReceiveCommentsHook extends AbstractHookController
 			// Get a table object for the new record to process in the event listeners
 			$issuetable = new IssuesTable($this->db);
 			$issueTable->load(
-			    array(
-			        'issue_number' => $this->hookData->issue->number,
-			        'project_id'   => $this->project->project_id,
-			    )
+				array(
+					'issue_number' => $this->hookData->issue->number,
+					'project_id'   => $this->project->project_id,
+				)
 			);
 
 			$this->triggerEvent('onCommentAfterCreate', $issueTable);
@@ -308,10 +308,10 @@ class ReceiveCommentsHook extends AbstractHookController
 		{
 			$issueTable = new IssuesTable($this->db);
 			$issueTable->load(
-			    array(
-			        'issue_number' => $this->hookData->issue->number,
-			        'project_id'   => $this->project->project_id,
-			    )
+				array(
+					'issue_number' => $this->hookData->issue->number,
+					'project_id'   => $this->project->project_id,
+				)
 			);
 
 			$this->triggerEvent('onCommentAfterUpdate', $issueTable);

--- a/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
@@ -266,8 +266,8 @@ class ReceiveCommentsHook extends AbstractHookController
 		// Only update fields that may have changed, there's no API endpoint to show that so make some guesses
 		$data = array();
 		$data['activities_id'] = $id;
-		$data['text'] = $parsedText;
-		$data['text_raw'] = $this->hookData->comment->body;
+		$data['text']          = $parsedText;
+		$data['text_raw']      = $this->hookData->comment->body;
 
 		try
 		{

--- a/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
@@ -131,7 +131,7 @@ class ReceiveCommentsHook extends AbstractHookController
 		try
 		{
 			// Get a table object for the new record to process in the event listeners
-			$issuetable = new IssuesTable($this->db);
+			$issueTable = new IssuesTable($this->db);
 			$issueTable->load(
 				array(
 					'issue_number' => $this->hookData->issue->number,


### PR DESCRIPTION
This PR try to implement the RTC Label Check to run also if a comment was add.

### What needs to be tested

- add a pull
- set status to RTC
- comment (using jissues)
- make sure the RTC label will add.
- add a new pull
- set the status to RTC
- comment (using github)
- make sure the RTC label will add.

I can't realy test it as i have no testserver setup. But in theory it should work or i miss something?

So it is not 100% idial but we have a bit more `automagic` in the Tracker.