### PR TITLE
Fix some possible setup errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "version": "1.0.0-beta",
     "require": {
         "php": ">=5.4.4",
+        "ext-curl": "*",
         "joomla/application": "~1.4",
         "joomla/controller": "~1.1",
         "joomla/database": "~1.1",

--- a/etc/config.dist.json
+++ b/etc/config.dist.json
@@ -59,7 +59,7 @@
 		"language": "0",
 		"hooks"   : "0",
 		"logging" : "0",
-		"log-path": "logs",
+		"log-path": "",
 		"admin"   : "1"
 	},
 

--- a/src/JTracker/Authentication/GitHub/GitHubLoginHelper.php
+++ b/src/JTracker/Authentication/GitHub/GitHubLoginHelper.php
@@ -134,6 +134,11 @@ class GitHubLoginHelper
 		$options   = new Registry;
 		$transport = HttpFactory::getAvailableDriver($options, array('curl'));
 
+		if (false == $transport)
+		{
+			throw new \DomainException('No transports available (please install php-curl)');
+		}
+
 		$http = new Http($options, $transport);
 
 		$data = array(


### PR DESCRIPTION
Hello again :wink: 

I recently had to setup my environment on a new computer and I ran into some installation problems, so this PR tries to fix this for new installs (exising install should not be affected so this should be full B/C :tongue:)

1. php-curl is not installed<br />
    In this case `HttpFactory::getAvailableDriver()` returns `false`. We miss a check in our `GitHubLoginHelper` here so the next call will produce a fatal error.<br />
    I also added the CURL extension as a dependency to our `composer.json` file so the application wouldn't even install if  CURL is not available.
2. The log path is not available<br />
    This might have changed in recent Apache versions, not sure. It is required to use a full path in the config file for the log path setting as a relative path would not work (at least on my system).

Please review.