### PR TITLE
Fix editor tabs in mobile view

### DIFF
--- a/templates/editor.twig
+++ b/templates/editor.twig
@@ -2,9 +2,9 @@
 {# GNU General Public License version 2 or later; see LICENSE.txt#}
 
 <ul class="nav nav-tabs">
+    <li class="pull-right"><a class="pull-right" href="http://issues.joomla.org/markdown" target="_blank"><span class="octicon octicon-markdown"></span> {{ "Markdown Help"|_ }}</a></li>
     <li class="active"><a href="#{{ writeId }}" data-toggle="tab">{{ "Write"|_ }}</a></li>
     <li><a href="#{{ previewId }}" data-toggle="tab">{{ "Preview"|_ }}</a></li>
-    <li class="pull-right"><a class="pull-right" href="http://issues.joomla.org/markdown" target="_blank"><span class="octicon octicon-markdown"></span> {{ "Markdown Help"|_ }}</a></li>
 </ul>
 
 <div class="tab-content">


### PR DESCRIPTION
This makes the tabs look *different* on small screens.

e.g.:

### Before
![screenshot_2015-07-08-10-21-00](https://cloud.githubusercontent.com/assets/33978/8575338/1c34fb32-2561-11e5-9d5a-c6fa0e421f0d.png)

## After
![screenshot_2015-07-08-09-12-40](https://cloud.githubusercontent.com/assets/33978/8575339/1c3c5f62-2561-11e5-8c71-811f7d009d4b.png)

As I am not the design guy I'd like you to review this please :wink: 

P.S.: Oh and there is a hard link to http://issues.joomla.org - while currently there is nothing wrong, maybe we should use `{{ uri.base.path }}` here to make it more portable?