### PR TITLE
PHPCS fixes based on PHPCS-2

### DIFF
--- a/cli/Application/Application.php
+++ b/cli/Application/Application.php
@@ -458,9 +458,7 @@ class Application extends AbstractCliApplication implements DispatcherAwareInter
 	 */
 	public function getProgressBar($targetNum)
 	{
-		return ($this->usePBar)
-			? new ConsoleProgressBar($this->pBarFormat, '=>', ' ', 60, $targetNum)
-			: null;
+		return ($this->usePBar) ? new ConsoleProgressBar($this->pBarFormat, '=>', ' ', 60, $targetNum) : null;
 	}
 
 	/**

--- a/cli/Application/Command/Clear/Clear.php
+++ b/cli/Application/Command/Clear/Clear.php
@@ -31,12 +31,12 @@ class Clear extends TrackerCommand
 	 *
 	 * NOTE: This command must not be executed without parameters !
 	 *
-	 * @return  $this
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
 	public function execute()
 	{
-		return $this->displayMissingOption(__DIR__);
+		$this->displayMissingOption(__DIR__);
 	}
 }

--- a/cli/Application/Command/Export/Export.php
+++ b/cli/Application/Command/Export/Export.php
@@ -21,7 +21,7 @@ class Export extends TrackerCommand
 	/**
 	 * The directory to receive the export.
 	 *
-	 * @var string
+	 * @var    string
 	 * @since  1.0
 	 */
 	protected $exportDir = '';
@@ -36,8 +36,11 @@ class Export extends TrackerCommand
 		$this->description = 'Export <cmd><langfiles></cmd>.';
 
 		$this->addOption(
-			new TrackerCommandOption('outputdir', 'o',
-				'The directory that should receive the export.')
+			new TrackerCommandOption(
+				'outputdir',
+				'o',
+				'The directory that should receive the export.'
+			)
 		);
 	}
 
@@ -46,13 +49,13 @@ class Export extends TrackerCommand
 	 *
 	 * NOTE: This command must not be executed without parameters !
 	 *
-	 * @return  $this
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
 	public function execute()
 	{
-		return $this->displayMissingOption(__DIR__);
+		$this->displayMissingOption(__DIR__);
 	}
 
 	/**

--- a/cli/Application/Command/Export/Langfiles.php
+++ b/cli/Application/Command/Export/Langfiles.php
@@ -60,10 +60,10 @@ class Langfiles extends Export
 	/**
 	 * Execute the command.
 	 *
-	 * @throws \RuntimeException
 	 * @return  void
 	 *
 	 * @since   1.0
+	 * @throws  \RuntimeException
 	 */
 	public function execute()
 	{

--- a/cli/Application/Command/Get/Avatars.php
+++ b/cli/Application/Command/Get/Avatars.php
@@ -112,9 +112,7 @@ class Avatars extends Get
 			{
 				$this->debugOut(sprintf(g11n3t('User avatar already fetched for user %s'), $username));
 
-				$this->usePBar
-					? $progressBar->update($i + 1)
-					: $this->out('-', false);
+				$this->usePBar ? $progressBar->update($i + 1) : $this->out('-', false);
 
 				continue;
 			}
@@ -139,9 +137,7 @@ class Avatars extends Get
 				);
 			}
 
-			$this->usePBar
-				? $progressBar->update($i + 1)
-				: $this->out('+', false);
+			$this->usePBar ? $progressBar->update($i + 1) : $this->out('+', false);
 		}
 
 		return $this->out()

--- a/cli/Application/Command/Get/Composertags.php
+++ b/cli/Application/Command/Get/Composertags.php
@@ -40,8 +40,8 @@ class Composertags extends Get
 	 *
 	 * @return  void
 	 *
-	 * @throws \UnexpectedValueException
 	 * @since   1.0
+	 * @throws  \UnexpectedValueException
 	 */
 	public function execute()
 	{

--- a/cli/Application/Command/Get/Get.php
+++ b/cli/Application/Command/Get/Get.php
@@ -85,13 +85,13 @@ class Get extends TrackerCommand
 	 *
 	 * NOTE: This command must not be executed without parameters !
 	 *
-	 * @return  $this
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
 	public function execute()
 	{
-		return $this->displayMissingOption(__DIR__);
+		$this->displayMissingOption(__DIR__);
 	}
 
 	/**

--- a/cli/Application/Command/Get/Project.php
+++ b/cli/Application/Command/Get/Project.php
@@ -346,7 +346,6 @@ class Project extends Get
 			return true;
 		}
 
-		return ($number >= $this->rangeFrom && $number <= $this->rangeTo)
-			? true : false;
+		return $number >= $this->rangeFrom && $number <= $this->rangeTo;
 	}
 }

--- a/cli/Application/Command/Get/Project/Comments.php
+++ b/cli/Application/Command/Get/Project/Comments.php
@@ -97,7 +97,7 @@ class Comments extends Project
 					'Fetching comments for <b>one</b> modified issue from GitHub...',
 					'Fetching comments for <b>%d</b> modified issues from GitHub...',
 					count($this->changedIssueNumbers)
-					),
+				),
 				count($this->changedIssueNumbers)
 			), false
 		);
@@ -108,12 +108,12 @@ class Comments extends Project
 
 		foreach ($this->changedIssueNumbers as $count => $issueNumber)
 		{
-			$this->usePBar
-				? $progressBar->update($count + 1)
-				: $this->out(
+			$this->usePBar ? $progressBar->update($count + 1) : $this->out(
 				sprintf(
 					'#%d (%d/%d):',
-					$issueNumber, $count, count($this->changedIssueNumbers)
+					$issueNumber,
+					$count,
+					count($this->changedIssueNumbers)
 				),
 				false
 			);
@@ -139,9 +139,7 @@ class Comments extends Project
 					$this->items[$issueNumber] = array_merge($this->items[$issueNumber], $comments);
 				}
 
-				$this->usePBar
-					? null
-					: $this->out($count . ' ', false);
+				$this->usePBar ? null : $this->out($count . ' ', false);
 			}
 
 			while ($count);
@@ -255,9 +253,7 @@ class Comments extends Project
 							if ($d1 == $d2)
 							{
 								// No update required
-								$this->usePBar
-									? $progressBar->update($i + 1)
-									: $this->out('-', false);
+								$this->usePBar ? $progressBar->update($i + 1) : $this->out('-', false);
 
 								continue;
 							}
@@ -305,9 +301,7 @@ class Comments extends Project
 						++ $adds;
 					}
 
-					$this->usePBar
-						? $progressBar->update($i + 1)
-						: null;
+					$this->usePBar ? $progressBar->update($i + 1) : null;
 				}
 
 				++ $count;

--- a/cli/Application/Command/Get/Project/Events.php
+++ b/cli/Application/Command/Get/Project/Events.php
@@ -122,14 +122,10 @@ class Events extends Project
 
 		foreach ($this->changedIssueNumbers as $count => $issueNumber)
 		{
-			$this->usePBar
-				? $progressBar->update($count + 1)
-				: $this->out(
-					sprintf(
-						'%d/%d - # %d: ', $count + 1, count($this->changedIssueNumbers), $issueNumber
-					),
-					false
-				);
+			$this->usePBar ? $progressBar->update($count + 1) : $this->out(
+				sprintf('%d/%d - # %d: ', $count + 1, count($this->changedIssueNumbers), $issueNumber),
+				false
+			);
 
 			$page = 0;
 			$this->items[$issueNumber] = array();
@@ -150,9 +146,7 @@ class Events extends Project
 				{
 					$this->items[$issueNumber] = array_merge($this->items[$issueNumber], $events);
 
-						$this->usePBar
-							? null
-							: $this->out($count . ' ', false);
+						$this->usePBar ? null : $this->out($count . ' ', false);
 				}
 			}
 
@@ -202,9 +196,7 @@ class Events extends Project
 
 		foreach ($this->items as $issueNumber => $events)
 		{
-			$this->usePBar
-				? null
-				: $this->out(sprintf(' #%d (%d/%d)...', $issueNumber, $count + 1, count($this->items)), false);
+			$this->usePBar ? null : $this->out(sprintf(' #%d (%d/%d)...', $issueNumber, $count + 1, count($this->items)), false);
 
 			foreach ($events as $event)
 			{
@@ -331,9 +323,7 @@ class Events extends Project
 
 			++ $count;
 
-			$this->usePBar
-				? $progressBar->update($count)
-				: null;
+			$this->usePBar ? $progressBar->update($count) : null;
 		}
 
 		$this->out()

--- a/cli/Application/Command/Get/Project/Issues.php
+++ b/cli/Application/Command/Get/Project/Issues.php
@@ -111,7 +111,7 @@ class Issues extends Project
 			{
 				$page++;
 				$issues_more = $this->github->issues->getListByRepository(
-				// Owner
+					// Owner
 					$this->project->gh_user,
 					// Repository
 					$this->project->gh_project,
@@ -200,9 +200,7 @@ class Issues extends Project
 		// Start processing the pulls now
 		foreach ($ghIssues as $count => $ghIssue)
 		{
-			$this->usePBar
-				? $progressBar->update($count + 1)
-				: $this->out($ghIssue->number . '...', false);
+			$this->usePBar ? $progressBar->update($count + 1) : $this->out($ghIssue->number . '...', false);
 
 			if (!$this->checkInRange($ghIssue->number))
 			{
@@ -286,9 +284,12 @@ class Issues extends Project
 			$table->modified_by   = $ghIssue->user->login;
 
 			$table->project_id = $this->project->project_id;
-			$table->milestone_id = ($ghIssue->milestone && isset($milestones[$ghIssue->milestone->number]))
-				? $milestones[$ghIssue->milestone->number]
-				: null;
+			$table->milestone_id = null;
+
+			if ($ghIssue->milestone && isset($milestones[$ghIssue->milestone->number]))
+			{
+				$table->milestone_id = $milestones[$ghIssue->milestone->number];
+			}
 
 			// We do not have a data about the default branch
 			// @todo We need to retrieve repository somehow
@@ -309,9 +310,7 @@ class Issues extends Project
 				$table->build = $pullRequest->base->ref;
 
 				// If the $pullRequest->head->user object is not set, the repo/branch had been deleted by the user.
-				$table->pr_head_user = (isset($pullRequest->head->user))
-					? $pullRequest->head->user->login
-					: 'unknown_repository';
+				$table->pr_head_user = (isset($pullRequest->head->user)) ? $pullRequest->head->user->login : 'unknown_repository';
 
 				$table->pr_head_ref  = $pullRequest->head->ref;
 
@@ -440,9 +439,9 @@ class Issues extends Project
 
 			$labelList = $db ->setQuery(
 				$db->getQuery(true)
-				->from($db->quoteName($table->getTableName()))
-				->select(array('label_id', 'name'))
-				->where($db->quoteName('project_id') . ' = ' . $this->project->project_id)
+					->from($db->quoteName($table->getTableName()))
+					->select(array('label_id', 'name'))
+					->where($db->quoteName('project_id') . ' = ' . $this->project->project_id)
 			)->loadObjectList();
 
 			foreach ($labelList as $labelObject)

--- a/cli/Application/Command/Get/Project/Labels.php
+++ b/cli/Application/Command/Get/Project/Labels.php
@@ -34,7 +34,7 @@ class Labels extends Project
 	/**
 	 * Execute the command.
 	 *
-	 * @return  $this
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */

--- a/cli/Application/Command/Get/Project/Milestones.php
+++ b/cli/Application/Command/Get/Project/Milestones.php
@@ -36,7 +36,7 @@ class Milestones extends Project
 	/**
 	 * Execute the command.
 	 *
-	 * @return  $this
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */

--- a/cli/Application/Command/Help/Help.php
+++ b/cli/Application/Command/Help/Help.php
@@ -65,7 +65,8 @@ class Help extends TrackerCommand
 		}
 
 		$this->out(
-			sprintf('<b>Usage:</b> <info>%s</info> <cmd><command></cmd> <opt>[options]</opt>',
+			sprintf(
+				'<b>Usage:</b> <info>%s</info> <cmd><command></cmd> <opt>[options]</opt>',
 				$executable
 			)
 		);
@@ -146,7 +147,7 @@ class Help extends TrackerCommand
 		{
 			$this->out()
 				->out('  Available <cmd>actions</cmd>:')
-			->out();
+				->out();
 
 			/* @type TrackerCommand $action */
 			foreach ($actions as $aName => $action)
@@ -180,10 +181,7 @@ class Help extends TrackerCommand
 	private function displayOption(TrackerCommandOption $option)
 	{
 		return $this->out()
-			->out(
-				($option->shortArg ? '<opt>-' . $option->shortArg . '</opt> | ' : '')
-				. '<opt>--' . $option->longArg . '</opt>'
-			)
+			->out(($option->shortArg ? '<opt>-' . $option->shortArg . '</opt> | ' : '') . '<opt>--' . $option->longArg . '</opt>')
 			->out('    ' . $option->description);
 	}
 

--- a/cli/Application/Command/Make/Composergraph.php
+++ b/cli/Application/Command/Make/Composergraph.php
@@ -63,7 +63,7 @@ class Composergraph extends Make
 	/**
 	 * Execute the command.
 	 *
-	 * @return  $this
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
@@ -86,8 +86,6 @@ class Composergraph extends Make
 		{
 			$this->show($format);
 		}
-
-		return $this;
 	}
 
 	/**

--- a/cli/Application/Command/Make/Dbcomments.php
+++ b/cli/Application/Command/Make/Dbcomments.php
@@ -129,16 +129,12 @@ class Dbcomments extends Make
 	 */
 	private function getType($type)
 	{
-		if (0 === strpos($type, 'int')
-			|| 0 === strpos($type, 'tinyint'))
+		if (0 === strpos($type, 'int') || 0 === strpos($type, 'tinyint'))
 		{
 			return 'integer';
 		}
 
-		if (0 === strpos($type, 'varchar')
-			|| 0 === strpos($type, 'text')
-			|| 0 === strpos($type, 'mediumtext')
-			|| 0 === strpos($type, 'datetime'))
+		if (0 === strpos($type, 'varchar') || 0 === strpos($type, 'text') || 0 === strpos($type, 'mediumtext') || 0 === strpos($type, 'datetime'))
 		{
 			return 'string';
 		}

--- a/cli/Application/Command/Make/Langfiles.php
+++ b/cli/Application/Command/Make/Langfiles.php
@@ -227,10 +227,7 @@ class Langfiles extends Make
 			$paths[] = $languageFile;
 			$paths[] = $templateFile;
 
-			$cmd = 'msgmerge --'
-				. implode(' --', $options)
-				. ' "' . implode('" "', $paths) . '"'
-				. ' 2>&1';
+			$cmd = 'msgmerge --' . implode(' --', $options) . ' "' . implode('" "', $paths) . '"' . ' 2>&1';
 
 			$this->debugOut($cmd);
 

--- a/cli/Application/Command/Make/Langtemplates.php
+++ b/cli/Application/Command/Make/Langtemplates.php
@@ -585,7 +585,7 @@ class Langtemplates extends Make
 	 *
 	 * @param   string  $dir  The directory to delete.
 	 *
-	 * @return  bool
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
@@ -601,9 +601,7 @@ class Langtemplates extends Make
 
 		foreach ($files as $file)
 		{
-			(is_dir($dir . '/' . $file))
-				? $this->delTree($dir . '/' . $file)
-				: unlink($dir . '/' . $file);
+			(is_dir($dir . '/' . $file)) ? $this->delTree($dir . '/' . $file) : unlink($dir . '/' . $file);
 		}
 
 		return rmdir($dir);

--- a/cli/Application/Command/Make/Make.php
+++ b/cli/Application/Command/Make/Make.php
@@ -43,7 +43,8 @@ class Make extends TrackerCommand
 	{
 		$this->addOption(
 			new TrackerCommandOption(
-				'noprogress', '',
+				'noprogress',
+				'',
 				'Don\'t use a progress bar.'
 			)
 		);
@@ -54,12 +55,12 @@ class Make extends TrackerCommand
 	 *
 	 * NOTE: This command must not be executed without parameters !
 	 *
-	 * @return  $this
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
 	public function execute()
 	{
-		return $this->displayMissingOption(__DIR__);
+		$this->displayMissingOption(__DIR__);
 	}
 }

--- a/cli/Application/Command/Test/Checkstyle.php
+++ b/cli/Application/Command/Test/Checkstyle.php
@@ -80,15 +80,11 @@ class Checkstyle extends Test
 
 		$this
 			->out()
-			->out(
-			$numErrors
-				? sprintf('<error> Finished with %d errors </error>', $numErrors)
-				: '<ok>Success</ok>'
-		);
+			->out($numErrors ? sprintf('<error> Finished with %d errors </error>', $numErrors) : '<ok>Success</ok>');
 
 		if ($this->exit)
 		{
-			exit($numErrors ? 1 : 0);
+			$this->getApplication()->close($numErrors ? 1 : 0);
 		}
 
 		return $numErrors;

--- a/cli/Application/Command/Test/Copypaste.php
+++ b/cli/Application/Command/Test/Copypaste.php
@@ -50,15 +50,11 @@ class Copypaste extends Test
 			)
 		);
 
-		$this->out(
-			$cloneCount
-				? sprintf('<error> %d clones found. </error>', $cloneCount)
-				: '<ok>No CP errors</ok>'
-		);
+		$this->out($cloneCount ? sprintf('<error> %d clones found. </error>', $cloneCount) : '<ok>No CP errors</ok>');
 
 		if ($this->exit)
 		{
-			exit($cloneCount ? 1 : 0);
+			$this->getApplication()->close($cloneCount ? 1 : 0);
 		}
 
 		return $cloneCount;

--- a/cli/Application/Command/Test/Hook.php
+++ b/cli/Application/Command/Test/Hook.php
@@ -168,7 +168,6 @@ class Hook extends Test
 			$db->getQuery(true)
 				->from($db->quoteName('#__tracker_projects'))
 				->select(array('project_id', 'title', 'gh_user', 'gh_project'))
-
 		)->loadObjectList();
 /*
 		$projectsModel = new ProjectsModel($this->getContainer()->get('db'), $this->getApplication()->input);

--- a/cli/Application/Command/Test/Langfiles.php
+++ b/cli/Application/Command/Test/Langfiles.php
@@ -74,9 +74,7 @@ class Langfiles extends Test
 				{
 					$path = $scopePath . '/' . $extensionPath . '/' . $language;
 
-					$path .= ('templates' == $language)
-						?  '/' . $extension . '.pot'
-						:  '/' . $language . '.' . $extension . '.po';
+					$path .= ('templates' == $language) ? '/' . $extension . '.pot' : '/' . $language . '.' . $extension . '.po';
 
 					$this->debugOut(sprintf('Check: %s-%s %s in %s', $domain, $extension, $language, $path));
 
@@ -114,15 +112,11 @@ class Langfiles extends Test
 			}
 		}
 
-		$this->out(
-			$errors
-			? '<error> There have been errors. </error>'
-			: '<ok>Language file syntax OK</ok>'
-		);
+		$this->out($errors ? '<error> There have been errors. </error>' : '<ok>Language file syntax OK</ok>');
 
 		if ($this->exit)
 		{
-			exit($errors ? 1 : 0);
+			$this->getApplication()->close($errors ? 1 : 0);
 		}
 
 		return ($errors ? 1 : 0);

--- a/cli/Application/Command/Test/Phploc.php
+++ b/cli/Application/Command/Test/Phploc.php
@@ -28,7 +28,7 @@ class Phploc extends Test
 	/**
 	 * Execute the command.
 	 *
-	 * @return  $this.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 * @throws  \UnexpectedValueException
@@ -58,7 +58,5 @@ class Phploc extends Test
 		);
 
 		$this->out('Finished');
-
-		return $this;
 	}
 }

--- a/cli/Application/Command/Test/Phpunit.php
+++ b/cli/Application/Command/Test/Phpunit.php
@@ -46,15 +46,11 @@ class Phpunit extends Test
 
 		$this
 			->out()
-			->out(
-			$returnVal
-				? '<error> Finished with errors. </error>'
-				: '<ok>Success</ok>'
-		);
+			->out($returnVal ? '<error> Finished with errors. </error>' : '<ok>Success</ok>');
 
 		if ($this->exit)
 		{
-			exit($returnVal ? 1 : 0);
+			$this->getApplication()->close($returnVal ? 1 : 0);
 		}
 
 		return $returnVal;

--- a/cli/Application/Command/Test/Run.php
+++ b/cli/Application/Command/Test/Run.php
@@ -34,6 +34,7 @@ class Run extends Test
 	{
 		$this->getApplication()->outputTitle('Test Suite');
 
+		// TODO - To be consistent with the abstract command's definition, execute() should have no return and the error count stored elsewhere
 		$statusCS = (new Checkstyle)
 			->setContainer($this->getContainer())
 			->setExit(false)
@@ -60,14 +61,9 @@ class Run extends Test
 
 		$status = ($statusCS || $statusUT) ? 1 : 0;
 
-		$this
-			->out()
-			->out(
-				$status
-					? '<error> Test Suite Finished with errors </error>.'
-					: '<ok>Test Suite Finished.</ok>'
-			);
+		$this->out()
+			->out($status ? '<error> Test Suite Finished with errors </error>.' : '<ok>Test Suite Finished.</ok>');
 
-		exit($status);
+		$this->getApplication()->close($status);
 	}
 }

--- a/cli/Application/Command/Test/Test.php
+++ b/cli/Application/Command/Test/Test.php
@@ -40,13 +40,13 @@ class Test extends TrackerCommand
 	 *
 	 * NOTE: This command must not be executed without parameters !
 	 *
-	 * @return  $this
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
 	public function execute()
 	{
-		return $this->displayMissingOption(__DIR__);
+		$this->displayMissingOption(__DIR__);
 	}
 
 	/**

--- a/cli/Application/Command/TrackerCommand.php
+++ b/cli/Application/Command/TrackerCommand.php
@@ -168,7 +168,7 @@ abstract class TrackerCommand implements LoggerAwareInterface, ContainerAwareInt
 	 *
 	 * @param   string  $dir  The base directory for the commands.
 	 *
-	 * @return  $this
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
@@ -203,9 +203,7 @@ abstract class TrackerCommand implements LoggerAwareInterface, ContainerAwareInt
 				continue;
 			}
 
-			$this->out('<error>  ' . $command . ' ' . $cmd
-				. str_repeat(' ', $maxLen - strlen($cmd) - strlen($command) + 1)
-				. '</error>');
+			$this->out('<error>  ' . $command . ' ' . $cmd . str_repeat(' ', $maxLen - strlen($cmd) - strlen($command) + 1) . '</error>');
 		}
 
 		$this->out('<error>  ' . str_repeat(' ', $maxLen) . '  </error>');
@@ -281,7 +279,6 @@ abstract class TrackerCommand implements LoggerAwareInterface, ContainerAwareInt
 			$db->getQuery(true)
 				->from($db->quoteName('#__tracker_projects'))
 				->select(array('project_id', 'title', 'gh_user', 'gh_project'))
-
 		)->loadObjectList();
 /*
 		$projectsModel = new ProjectsModel($this->getContainer()->get('db'), $this->getApplication()->input);

--- a/cli/Application/Command/Update/Pulls.php
+++ b/cli/Application/Command/Update/Pulls.php
@@ -52,11 +52,11 @@ class Pulls extends Update
 			->displayGitHubRateLimit()
 			->out(
 				sprintf(
-						'Updating pull requests for project: %s/%s',
-						$this->project->gh_user,
-						$this->project->gh_project
-					)
+					'Updating pull requests for project: %s/%s',
+					$this->project->gh_user,
+					$this->project->gh_project
 				)
+			)
 			->fetchPulls()
 			->labelPulls()
 			->updatePullStatus()

--- a/cli/Application/Command/Update/Server.php
+++ b/cli/Application/Command/Update/Server.php
@@ -104,7 +104,8 @@ class Server extends Update
 							sprintf(
 								g11n3t(
 									'SQL query failed, please verify the database structure and finish the update '
-									. 'manually.  The database error message is: %s'),
+									. 'manually.  The database error message is: %s'
+								),
 								$e->getMessage()
 							)
 						);

--- a/cli/Application/Command/Update/Update.php
+++ b/cli/Application/Command/Update/Update.php
@@ -56,13 +56,15 @@ class Update extends TrackerCommand
 		$this
 			->addOption(
 				new TrackerCommandOption(
-					'project', 'p',
+					'project',
+					'p',
 					'Process the project with the given ID.'
 				)
 			)
 			->addOption(
 				new TrackerCommandOption(
-					'noprogress', '',
+					'noprogress',
+					'',
 					'Don\'t use a progress bar.'
 				)
 		);
@@ -73,13 +75,13 @@ class Update extends TrackerCommand
 	 *
 	 * NOTE: This command must not be executed without parameters !
 	 *
-	 * @return  $this
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
 	public function execute()
 	{
-		return $this->displayMissingOption(__DIR__);
+		$this->displayMissingOption(__DIR__);
 	}
 
 	/**

--- a/src/App/Debug/TrackerDebugger.php
+++ b/src/App/Debug/TrackerDebugger.php
@@ -199,7 +199,7 @@ class TrackerDebugger implements LoggerAwareInterface
 
 		$entry = new \stdClass;
 
-		$entry->sql   = isset($context['sql'])   ? $context['sql']   : 'n/a';
+		$entry->sql   = isset($context['sql']) ? $context['sql'] : 'n/a';
 		$entry->times = isset($context['times']) ? $context['times'] : 'n/a';
 		$entry->trace = isset($context['trace']) ? $context['trace'] : 'n/a';
 
@@ -385,10 +385,10 @@ class TrackerDebugger implements LoggerAwareInterface
 
 			$navigation[] = '<li class="hasTooltip"'
 				. ' title="' . sprintf(
-					g11n4t(
-							'One untranslated string of %2$d', '%1$d untranslated strings of %2$d', $info->untranslateds
-						), $info->untranslateds, $info->total
-					) . '">'
+					g11n4t('One untranslated string of %2$d', '%1$d untranslated strings of %2$d', $info->untranslateds),
+					$info->untranslateds,
+					$info->total
+				) . '">'
 				. '<a href="#dbgLanguageStrings"><i class="icon icon-question-sign"></i>  '
 				. $badge . '/' . $this->getBadge($info->total)
 				. '</a></li>';
@@ -414,9 +414,7 @@ class TrackerDebugger implements LoggerAwareInterface
 			{
 				$build = trim(file_get_contents(JPATH_ROOT . '/current_SHA'));
 				preg_match('/-g([0-9a-z]+)/', $build, $matches);
-				$buildHref = $matches
-					? 'https://github.com/joomla/jissues/commit/' . $matches[1]
-					: '#';
+				$buildHref = $matches ? 'https://github.com/joomla/jissues/commit/' . $matches[1] : '#';
 			}
 			// Fall back to composer.json version
 			else
@@ -506,10 +504,9 @@ class TrackerDebugger implements LoggerAwareInterface
 		}
 
 		$pluralInfo = sprintf(
-			g11n3t(
-				'Plural forms: <code>%1$d</code><br />Plural function: <code>%2$s</code>'),
-			g11n::get('pluralForms'), g11n::get('pluralFunctionRaw'
-			)
+			g11n3t('Plural forms: <code>%1$d</code><br />Plural function: <code>%2$s</code>'),
+			g11n::get('pluralForms'),
+			g11n::get('pluralFunctionRaw')
 		);
 
 		return $tableFormat->fromArray($items) . $pluralInfo;
@@ -535,8 +532,8 @@ class TrackerDebugger implements LoggerAwareInterface
 			$this->logger->error($exception->getCode() . ' ' . $exception->getMessage(), $context);
 
 			return str_replace(JPATH_ROOT, 'JROOT', $exception->getMessage())
-			. '<pre>' . $exception->getTraceAsString() . '</pre>'
-			. 'Previous: ' . get_class($exception->getPrevious());
+				. '<pre>' . $exception->getTraceAsString() . '</pre>'
+				. 'Previous: ' . get_class($exception->getPrevious());
 		}
 
 		$view = new \JTracker\View\TrackerDefaultView;
@@ -733,9 +730,7 @@ class TrackerDebugger implements LoggerAwareInterface
 
 		foreach ($items as $string => $item)
 		{
-			$color =('-' == $item->status)
-				? '#ffb2b2;'
-				: '#e5ff99;';
+			$color = ('-' == $item->status) ? '#ffb2b2;' : '#e5ff99;';
 
 			$html[] = '<tr>';
 			$html[] = '<td style="border-left: 7px solid ' . $color . '">' . htmlentities($string) . '</td>';
@@ -743,9 +738,9 @@ class TrackerDebugger implements LoggerAwareInterface
 			$html[] = '<td><span class="btn btn-mini" onclick="$(\'#langStringTrace' . $i . '\').slideToggle();">Trace</span></td>';
 			$html[] = '</tr>';
 
-			$html[] = '<tr><td colspan="4" id="langStringTrace' . $i . '" style="display: none;">'
-				. $tableFormat->fromTrace($item->trace)
-				. '</td></tr>';
+			$html[] = '<tr>';
+			$html[] = '<td colspan="4" id="langStringTrace' . $i . '" style="display: none;">' . $tableFormat->fromTrace($item->trace) . '</td>';
+			$html[] = '</tr>';
 
 			$i ++;
 		}

--- a/src/App/Debug/View/Logs/LogsHtmlView.php
+++ b/src/App/Debug/View/Logs/LogsHtmlView.php
@@ -69,9 +69,7 @@ class LogsHtmlView extends AbstractTrackerHtmlView
 			break;
 		}
 
-		$log = (realpath($path))
-			? $this->processLog($type, $path)
-			: [sprintf(g11n3t('No %s log file found.'), $type)];
+		$log = (realpath($path)) ? $this->processLog($type, $path) : [sprintf(g11n3t('No %s log file found.'), $type)];
 
 		$this->renderer->set('log', $log);
 		$this->renderer->set('log_type', $type);

--- a/src/App/Groups/Table/GroupsTable.php
+++ b/src/App/Groups/Table/GroupsTable.php
@@ -74,11 +74,11 @@ class GroupsTable extends AbstractDatabaseTable
 		$this->system     = (int) $src->get('system');
 
 		// The following values come in as checkboxes ¡: "ON" or not set.
-		$this->can_view    = $src->get('can_view')    ? 1 : 0;
-		$this->can_create  = $src->get('can_create')  ? 1 : 0;
-		$this->can_edit    = $src->get('can_edit')    ? 1 : 0;
+		$this->can_view    = $src->get('can_view') ? 1 : 0;
+		$this->can_create  = $src->get('can_create') ? 1 : 0;
+		$this->can_edit    = $src->get('can_edit') ? 1 : 0;
 		$this->can_editown = $src->get('can_editown') ? 1 : 0;
-		$this->can_manage  = $src->get('can_manage')  ? 1 : 0;
+		$this->can_manage  = $src->get('can_manage') ? 1 : 0;
 
 		return $this;
 	}
@@ -124,8 +124,8 @@ class GroupsTable extends AbstractDatabaseTable
 		// Delete the entries in the map table.
 		$this->db->setQuery(
 			$this->db->getQuery(true)
-			->delete($this->db->quoteName('#__user_accessgroup_map'))
-			->where($this->db->quoteName('group_id') . ' = ' . (int) $this->group_id)
+				->delete($this->db->quoteName('#__user_accessgroup_map'))
+				->where($this->db->quoteName('group_id') . ' = ' . (int) $this->group_id)
 		)->execute();
 
 		return $this;

--- a/src/App/Projects/Controller/Project/Delete.php
+++ b/src/App/Projects/Controller/Project/Delete.php
@@ -53,6 +53,8 @@ class Delete extends AbstractTrackerController
 		$this->getContainer()->get('app')->getUser()->authorize('admin');
 
 		$this->model->setUser($this->getContainer()->get('app')->getUser());
+
+		return $this;
 	}
 
 	/**

--- a/src/App/Projects/Model/ProjectModel.php
+++ b/src/App/Projects/Model/ProjectModel.php
@@ -95,8 +95,8 @@ class ProjectModel extends AbstractTrackerDatabaseModel
 		// Delete access groups associated with the project
 		$this->db->setQuery(
 			$this->db->getQuery(true)
-			->delete($this->db->quoteName('#__accessgroups'))
-			->where($this->db->quoteName('project_id') . '=' . (int) $project->project_id)
+				->delete($this->db->quoteName('#__accessgroups'))
+				->where($this->db->quoteName('project_id') . '=' . (int) $project->project_id)
 		)->execute();
 
 		// @todo: cleanup more.

--- a/src/App/Projects/Model/ProjectsModel.php
+++ b/src/App/Projects/Model/ProjectsModel.php
@@ -88,9 +88,7 @@ class ProjectsModel extends AbstractTrackerListModel
 
 		// Public
 		$query->leftJoin(
-			$db->quoteName('#__accessgroups', 'g')
-			. ' ON ' . $db->quoteName('g.project_id')
-			. ' = ' . $db->quoteName('p.project_id')
+			$db->quoteName('#__accessgroups', 'g') . ' ON ' . $db->quoteName('g.project_id') . ' = ' . $db->quoteName('p.project_id')
 		);
 
 		$query->where($db->quoteName('g.title') . ' = ' . $db->quote('Public'));
@@ -100,17 +98,12 @@ class ProjectsModel extends AbstractTrackerListModel
 		if ($this->getUser()->id)
 		{
 			$query->leftJoin(
-				$db->quoteName('#__accessgroups', 'g1')
-				. ' ON ' . $db->quoteName('g1.project_id')
-				. ' = ' . $db->quoteName('p.project_id')
+				$db->quoteName('#__accessgroups', 'g1') . ' ON ' . $db->quoteName('g1.project_id') . ' = ' . $db->quoteName('p.project_id')
 			);
 
 			$query->clear('where');
 
-			$where = '';
-
-			$where .=
-				'('
+			$where = '('
 				. $db->quoteName('g.title') . ' = ' . $db->quote('Public')
 				. ' AND ' . $db->quoteName('g.can_view') . ' = 1'
 				. ') OR ('

--- a/src/App/Projects/TrackerProject.php
+++ b/src/App/Projects/TrackerProject.php
@@ -258,9 +258,9 @@ class TrackerProject implements \Serializable
 			// Only for existing projects
 			$groups = $db->setQuery(
 				$db->getQuery(true)
-				->from($db->quoteName('#__accessgroups'))
-				->select('*')
-				->where($db->quoteName('project_id') . ' = ' . (int) $this->project_id)
+					->from($db->quoteName('#__accessgroups'))
+					->select('*')
+					->where($db->quoteName('project_id') . ' = ' . (int) $this->project_id)
 			)->loadObjectList();
 
 			if (!$groups)

--- a/src/App/Support/Controller/Documentation.php
+++ b/src/App/Support/Controller/Documentation.php
@@ -51,5 +51,7 @@ class Documentation extends AbstractTrackerController
 
 			$this->view->setFullPath($fullPath);
 		}
+
+		return $this;
 	}
 }

--- a/src/App/Support/Controller/Filetree.php
+++ b/src/App/Support/Controller/Filetree.php
@@ -54,9 +54,9 @@ class Filetree extends AbstractTrackerController
 					// Dumb spoof check
 					$file = str_replace('..', '', $file);
 
-					$response[] = '<li class="directory collapsed">'
-						. '<a href="javascript:;" rel="' . $path . '/' . $file . '">' . htmlentities($file) . '</a>'
-						. '</li>';
+					$response[] = '<li class="directory collapsed">';
+					$response[] = '<a href="javascript:;" rel="' . $path . '/' . $file . '">' . htmlentities($file) . '</a>';
+					$response[] = '</li>';
 				}
 			}
 
@@ -74,11 +74,9 @@ class Filetree extends AbstractTrackerController
 
 					$fullPath = 'page=' . htmlentities($page) . ($subPath ? '&path=' . htmlentities($subPath) : '');
 
-					$response[] = '<li class="file ext_' . $ext . '">'
-						. '<a href="javascript:;" rel="' . $fullPath . '">'
-						. $this->getTitle($file)
-						. '</a>'
-						. '</li>';
+					$response[] = '<li class="file ext_' . $ext . '">';
+					$response[] = '<a href="javascript:;" rel="' . $fullPath . '">' . $this->getTitle($file) . '</a>';
+					$response[] = '</li>';
 				}
 			}
 

--- a/src/App/System/Controller/Config/Save.php
+++ b/src/App/System/Controller/Config/Save.php
@@ -20,7 +20,7 @@ class Save extends AbstractTrackerController
 	/**
 	 * Execute the controller.
 	 *
-	 * @return  string
+	 * @return  void  Redirects the application
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException

--- a/src/App/Text/Controller/Article/Add.php
+++ b/src/App/Text/Controller/Article/Add.php
@@ -73,5 +73,7 @@ class Add extends AbstractTrackerController
 		parent::initialize();
 
 		$this->view->setItem(new ArticlesTable($this->getContainer()->get('db')));
+
+		return $this;
 	}
 }

--- a/src/App/Text/Controller/Article/Edit.php
+++ b/src/App/Text/Controller/Article/Edit.php
@@ -66,5 +66,7 @@ class Edit extends AbstractTrackerController
 		$this->getContainer()->get('app')->getUser()->authorize('admin');
 
 		$this->view->setItem($this->model->getItem($this->getContainer()->get('app')->input->getInt('id')));
+
+		return $this;
 	}
 }

--- a/src/App/Text/Controller/Page.php
+++ b/src/App/Text/Controller/Page.php
@@ -42,5 +42,7 @@ class Page extends AbstractTrackerController
 		parent::initialize();
 
 		$this->view->setAlias($this->getContainer()->get('app')->input->getCmd('alias'));
+
+		return $this;
 	}
 }

--- a/src/App/Tracker/Controller/Category/Save.php
+++ b/src/App/Tracker/Controller/Category/Save.php
@@ -38,7 +38,7 @@ class Save extends AbstractTrackerController
 	/**
 	 * Execute the controller.
 	 *
-	 * @return  string
+	 * @return  void  Redirects the application
 	 *
 	 * @since   1.0
 	 */
@@ -83,7 +83,5 @@ class Save extends AbstractTrackerController
 				$app->redirect($app->get('uri.base.path') . 'category/' . $project->alias . '/add');
 			}
 		}
-
-		parent::execute();
 	}
 }

--- a/src/App/Tracker/Controller/DefaultController.php
+++ b/src/App/Tracker/Controller/DefaultController.php
@@ -149,11 +149,13 @@ class DefaultController extends AbstractTrackerListController
 
 		$state->set('filter.state', $issuesState);
 
-		$state->set('filter.status',
+		$state->set(
+			'filter.status',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.status', 'status', 0, 'uint')
 		);
 
-		$state->set('filter.search',
+		$state->set(
+			'filter.search',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.search', 'search', '', 'string')
 		);
 
@@ -173,7 +175,8 @@ class DefaultController extends AbstractTrackerListController
 
 		$state->set('filter.user', $user);
 
-		$state->set('filter.created_by',
+		$state->set(
+			'filter.created_by',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.created_by', 'created_by', '', 'string')
 		);
 
@@ -201,7 +204,8 @@ class DefaultController extends AbstractTrackerListController
 
 		$state->set('filter.label', $application->getUserStateFromRequest('project_' . $projectId . '.filter.label', 'label', 0, 'uint'));
 
-		$state->set('stools-active',
+		$state->set(
+			'stools-active',
 			$application->input->get('stools-active', 0, 'uint')
 		);
 
@@ -211,15 +215,18 @@ class DefaultController extends AbstractTrackerListController
 		}
 
 		// Update the page from the GET request
-		$state->set('page',
+		$state->set(
+			'page',
 			$application->getUserStateFromRequest('project_' . $projectId . '.page', 'page', 1, 'uint')
 		);
 
-		$state->set('filter.tests',
+		$state->set(
+			'filter.tests',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.tests', 'tests', 0, 'uint')
 		);
 
-		$state->set('filter.easytest',
+		$state->set(
+			'filter.easytest',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.easytest', 'easytest', 0, 'uint')
 		);
 

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -447,9 +447,11 @@ class JoomlacmsPullsListener
 					// Check for file paths administrator/language, installation/language, and language at position 0
 					if (!$addLanguageLabel)
 					{
-						if (strpos($file->filename, 'administrator/language') === 0
+						if (
+							strpos($file->filename, 'administrator/language') === 0
 							|| strpos($file->filename, 'installation/language') === 0
-							|| strpos($file->filename, 'language') === 0)
+							|| strpos($file->filename, 'language') === 0
+						)
 						{
 							$addLanguageLabel = true;
 						}

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -447,11 +447,9 @@ class JoomlacmsPullsListener
 					// Check for file paths administrator/language, installation/language, and language at position 0
 					if (!$addLanguageLabel)
 					{
-						if (
-							strpos($file->filename, 'administrator/language') === 0
+						if (strpos($file->filename, 'administrator/language') === 0
 							|| strpos($file->filename, 'installation/language') === 0
-							|| strpos($file->filename, 'language') === 0
-						)
+							|| strpos($file->filename, 'language') === 0)
 						{
 							$addLanguageLabel = true;
 						}

--- a/src/App/Tracker/Controller/Issue/Add.php
+++ b/src/App/Tracker/Controller/Issue/Add.php
@@ -75,5 +75,7 @@ class Add extends AbstractTrackerController
 
 		$this->view->setProject($this->getContainer()->get('app')->getProject());
 		$this->view->setItem($item);
+
+		return $this;
 	}
 }

--- a/src/App/Tracker/Controller/Issue/Ajax/Listing.php
+++ b/src/App/Tracker/Controller/Issue/Ajax/Listing.php
@@ -90,47 +90,58 @@ class Listing extends AbstractAjaxController
 
 		$state->set('filter.sort', $sort);
 
-		$state->set('filter.priority',
+		$state->set(
+			'filter.priority',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.priority', 'priority', 0, 'uint')
 		);
 
-		$state->set('filter.state',
+		$state->set(
+			'filter.state',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.state', 'state', 0, 'uint')
 		);
 
-		$state->set('filter.status',
+		$state->set(
+			'filter.status',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.status', 'status', 0, 'uint')
 		);
 
-		$state->set('filter.search',
+		$state->set(
+			'filter.search',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.search', 'search', '', 'string')
 		);
 
-		$state->set('filter.user',
+		$state->set(
+			'filter.user',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.user', 'user', 0, 'uint')
 		);
 
-		$state->set('filter.created_by',
+		$state->set(
+			'filter.created_by',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.created_by', 'created_by', '', 'string')
 		);
 
-		$state->set('filter.category',
+		$state->set(
+			'filter.category',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.category', 'category', 0, 'int')
 		);
 
-		$state->set('filter.label',
+		$state->set(
+			'filter.label',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.label', 'label', 0, 'uint')
 		);
 
-		$state->set('filter.tests',
+		$state->set(
+			'filter.tests',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.tests', 'tests', 0, 'uint')
 		);
 
-		$state->set('filter.easytest',
+		$state->set(
+			'filter.easytest',
 			$application->getUserStateFromRequest('project_' . $projectId . '.filter.easytest', 'easytest', 0, 'uint')
 		);
 
-		$state->set('stools-active',
+		$state->set(
+			'stools-active',
 			$application->input->get('stools-active', 0, 'uint')
 		);
 

--- a/src/App/Tracker/Controller/Issue/Random.php
+++ b/src/App/Tracker/Controller/Issue/Random.php
@@ -22,7 +22,7 @@ class Random extends AbstractTrackerController
 	/**
 	 * Execute the controller.
 	 *
-	 * @return  string  The rendered view.
+	 * @return  void  Redirects the application
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
@@ -40,8 +40,7 @@ class Random extends AbstractTrackerController
 				->getRandomNumber();
 
 			$application->redirect(
-				$application->get('uri.base.path')
-				. '/tracker/' . $application->input->get('project_alias') . '/' . $randomNumber
+				$application->get('uri.base.path') . '/tracker/' . $application->input->get('project_alias') . '/' . $randomNumber
 			);
 		}
 		catch (\Exception $e)
@@ -49,11 +48,8 @@ class Random extends AbstractTrackerController
 			$application->enqueueMessage($e->getMessage(), 'error');
 
 			$application->redirect(
-				$application->get('uri.base.path')
-				. 'tracker/' . $application->input->get('project_alias')
+				$application->get('uri.base.path') . 'tracker/' . $application->input->get('project_alias')
 			);
 		}
-
-		parent::execute();
 	}
 }

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -283,9 +283,7 @@ class Save extends AbstractTrackerController
 			}
 
 			$application->enqueueMessage('The changes have been saved.', 'success')
-				->redirect(
-				'/tracker/' . $application->input->get('project_alias') . '/' . $issueNumber
-			);
+				->redirect('/tracker/' . $application->input->get('project_alias') . '/' . $issueNumber);
 		}
 		catch (\RuntimeException $exception)
 		{
@@ -293,8 +291,7 @@ class Save extends AbstractTrackerController
 
 			// @todo preserve data when returning to edit view on failure.
 			$application->redirect(
-				$application->get('uri.base.path')
-				. 'tracker/' . $application->input->get('project_alias') . '/' . $issueNumber . '/edit'
+				$application->get('uri.base.path') . 'tracker/' . $application->input->get('project_alias') . '/' . $issueNumber . '/edit'
 			);
 		}
 
@@ -360,8 +357,7 @@ class Save extends AbstractTrackerController
 
 			// The milestone and labels are silently dropped,
 			// so try to update the milestone and/or labels if they are not set.
-			if ((!empty($milestone) && empty($gitHubResponse->milestone)
-				|| (!empty($milestone) && $milestone != $gitHubResponse->milestone)))
+			if (!empty($milestone) && empty($gitHubResponse->milestone) || (!empty($milestone) && $milestone != $gitHubResponse->milestone))
 			{
 				$needUpdate = true;
 			}
@@ -437,8 +433,7 @@ class Save extends AbstractTrackerController
 
 			// The milestone and labels are silently dropped,
 			// so try to update the milestone and/or labels if they are not set.
-			if ((!empty($milestone) && empty($gitHubResponse->milestone)
-				|| (!empty($milestone) && $milestone != $gitHubResponse->milestone)))
+			if (!empty($milestone) && empty($gitHubResponse->milestone) || (!empty($milestone) && $milestone != $gitHubResponse->milestone))
 			{
 				$needUpdate = true;
 			}

--- a/src/App/Tracker/Controller/Issue/Submit.php
+++ b/src/App/Tracker/Controller/Issue/Submit.php
@@ -165,16 +165,14 @@ class Submit extends AbstractTrackerController
 			$application->enqueueMessage($e->getMessage(), 'error');
 
 			$application->redirect(
-				$application->get('uri.base.path')
-				. 'tracker/' . $project->alias . '/add'
+				$application->get('uri.base.path') . 'tracker/' . $project->alias . '/add'
 			);
 		}
 
 		$application->enqueueMessage(g11n3t('Your report has been submitted.'), 'success');
 
 		$application->redirect(
-			$application->get('uri.base.path')
-			. 'tracker/' . $project->alias . '/' . $data['number']
+			$application->get('uri.base.path') . 'tracker/' . $project->alias . '/' . $data['number']
 		);
 
 		return;
@@ -254,13 +252,18 @@ class Submit extends AbstractTrackerController
 		 */
 		if (isset($gitHubBot))
 		{
-			if ((!empty($milestone) && empty($gitHubResponse->milestone))
-				|| (!empty($labels) && empty($gitHubResponse->labels)))
+			if ((!empty($milestone) && empty($gitHubResponse->milestone)) || (!empty($labels) && empty($gitHubResponse->labels)))
 			{
 				$gitHubBot->issues->edit(
-					$project->gh_user, $project->gh_project,
-					$gitHubResponse->number, 'open', $title, $body,
-					$assignee, $milestone, $labels
+					$project->gh_user,
+					$project->gh_project,
+					$gitHubResponse->number,
+					'open',
+					$title,
+					$body,
+					$assignee,
+					$milestone,
+					$labels
 				);
 			}
 		}

--- a/src/App/Tracker/Model/IssueModel.php
+++ b/src/App/Tracker/Model/IssueModel.php
@@ -60,12 +60,7 @@ class IssueModel extends AbstractTrackerDatabaseModel
 				// Join over the status table
 				->select($this->db->quoteName('s.status', 'status_title'))
 				->select($this->db->quoteName('s.closed', 'closed'))
-				->leftJoin(
-					$this->db->quoteName('#__status', 's')
-					. ' ON '
-					. $this->db->quoteName('i.status')
-					. ' = ' . $this->db->quoteName('s.id')
-				)
+				->join('LEFT', '#__status AS s ON i.status = s.id')
 
 				// Get the relation information
 				->select('a1.title AS rel_title, a1.status AS rel_status')
@@ -85,7 +80,7 @@ class IssueModel extends AbstractTrackerDatabaseModel
 
 				// Join over the users
 				->select('u.id AS user_id')
-				->leftJoin('#__users AS u ON i.opened_by = u.username')
+				->join('LEFT', '#__users AS u ON i.opened_by = u.username')
 		)->loadObject();
 
 		if (!$item)
@@ -129,7 +124,7 @@ class IssueModel extends AbstractTrackerDatabaseModel
 
 					$activities[] = $a;
 
-					unset ($commits[$i1]);
+					unset($commits[$i1]);
 				}
 			}
 
@@ -474,12 +469,7 @@ class IssueModel extends AbstractTrackerDatabaseModel
 			$query->clear()
 				->insert($db->quoteName('#__issues_voting'))
 				->columns($columnsArray)
-				->values(
-					$id . ', '
-					. $userID . ', '
-					. $experienced . ', '
-					. $importance
-				);
+				->values(implode(', ', [$id, $userID, $experienced, $importance]));
 		}
 		else
 		{

--- a/src/App/Tracker/Model/IssuesModel.php
+++ b/src/App/Tracker/Model/IssuesModel.php
@@ -436,10 +436,7 @@ class IssuesModel extends AbstractTrackerListModel
 		{
 			// Common query elements
 			$query
-				->leftJoin(
-					$db->quoteName('#__issues_tests', 'it')
-					. 'ON a.id = it.item_id'
-				)
+				->leftJoin($db->quoteName('#__issues_tests', 'it') . 'ON a.id = it.item_id')
 				->where($db->quoteName('a.has_code') . ' = 1')
 				->group('a.issue_number');
 

--- a/src/App/Users/Controller/Ajax/Search.php
+++ b/src/App/Users/Controller/Ajax/Search.php
@@ -44,9 +44,7 @@ class Search extends AbstractAjaxController
 			if ($inGroupId || $notInGroupId)
 			{
 				$query->leftJoin(
-					$db->quoteName('#__user_accessgroup_map', 'm')
-					. ' ON ' . $db->quoteName('m.user_id')
-					. ' = ' . $db->quoteName('u.id')
+					$db->quoteName('#__user_accessgroup_map', 'm') . ' ON ' . $db->quoteName('m.user_id') . ' = ' . $db->quoteName('u.id')
 				);
 
 				if ($inGroupId)
@@ -55,13 +53,13 @@ class Search extends AbstractAjaxController
 				}
 				elseif ($notInGroupId)
 				{
+					$subQuery = $db->getQuery(true)
+						->from($db->quoteName('#__user_accessgroup_map'))
+						->select($db->quoteName('user_id'))
+						->where($db->quoteName('group_id') . ' = ' . (int) $notInGroupId);
+
 					$query->where(
-						$db->quoteName('u.id') . ' NOT IN ('
-						. $db->getQuery(true)
-							->from($db->quoteName('#__user_accessgroup_map'))
-							->select($db->quoteName('user_id'))
-							->where($db->quoteName('group_id') . ' = ' . (int) $notInGroupId)
-						. ')'
+						$db->quoteName('u.id') . ' NOT IN (' . $subQuery . ')'
 					);
 				}
 			}

--- a/src/App/Users/Controller/Login.php
+++ b/src/App/Users/Controller/Login.php
@@ -28,7 +28,7 @@ class Login extends AbstractTrackerController
 	/**
 	 * Execute the controller.
 	 *
-	 * @return  string  The rendered view.
+	 * @return  void  Redirects the application
 	 *
 	 * @since   1.0
 	 * @throws  AuthenticationException

--- a/src/App/Users/Controller/User.php
+++ b/src/App/Users/Controller/User.php
@@ -65,5 +65,7 @@ class User extends AbstractTrackerController
 		$this->view->id = (int) $id;
 
 		$this->model->setProject($this->getContainer()->get('app')->getProject());
+
+		return $this;
 	}
 }

--- a/src/App/Users/Controller/User/Edit.php
+++ b/src/App/Users/Controller/User/Edit.php
@@ -92,5 +92,7 @@ class Edit extends AbstractTrackerController
 		$this->view->id = $id;
 
 		$this->model->setProject($this->getContainer()->get('app')->getProject());
+
+		return $this;
 	}
 }

--- a/src/App/Users/Controller/User/Refresh.php
+++ b/src/App/Users/Controller/User/Refresh.php
@@ -45,8 +45,7 @@ class Refresh extends AbstractTrackerController
 			{
 				$application->enqueueMessage(
 					g11n3t('You are not authorized to refresh this user.'), 'error'
-				)
-					->redirect(
+				)->redirect(
 					$application->get('uri.base.path') . 'user/' . $id
 				);
 			}
@@ -80,8 +79,7 @@ class Refresh extends AbstractTrackerController
 
 		$application->enqueueMessage(
 			g11n3t('The profile has been refreshed.'), 'success'
-		)
-			->redirect(
+		)->redirect(
 			$application->get('uri.base.path') . 'user/' . $id
 		);
 

--- a/src/App/Users/Controller/User/Save.php
+++ b/src/App/Users/Controller/User/Save.php
@@ -22,7 +22,7 @@ class Save extends AbstractTrackerController
 	/**
 	 * Execute the controller.
 	 *
-	 * @return  string  The rendered view.
+	 * @return  void  Redirects the application
 	 *
 	 * @since   1.0
 	 * @throws  \UnexpectedValueException
@@ -48,8 +48,8 @@ class Save extends AbstractTrackerController
 				);
 
 				$application->redirect(
-						$application->get('uri.base.path') . 'user/' . $src['id']
-					);
+					$application->get('uri.base.path') . 'user/' . $src['id']
+				);
 			}
 		}
 
@@ -70,7 +70,5 @@ class Save extends AbstractTrackerController
 		$application->redirect(
 			$application->get('uri.base.path') . 'user/' . $src['id'] . '/edit'
 		);
-
-		parent::execute();
 	}
 }

--- a/src/App/Users/Controller/Users.php
+++ b/src/App/Users/Controller/Users.php
@@ -33,7 +33,8 @@ class Users extends AbstractTrackerListController
 
 		$state = $this->model->getState();
 
-		$state->set('filter.search-user',
+		$state->set(
+			'filter.search-user',
 			$application->getUserStateFromRequest('filter.search-user', 'search-user', '', 'string')
 		);
 

--- a/src/JTracker/Application.php
+++ b/src/JTracker/Application.php
@@ -445,9 +445,7 @@ final class Application extends AbstractWebApplication implements ContainerAware
 		// Add the App domain path.
 		g11n::addDomainPath('App', JPATH_ROOT . '/src/App');
 
-		if ($this->get('debug.system')
-			|| $this->get('debug.database')
-			|| $this->get('debug.language'))
+		if ($this->get('debug.system') || $this->get('debug.database') || $this->get('debug.language'))
 		{
 			// Load the Debug App language file.
 			g11n::loadLanguage('Debug', 'App');

--- a/src/JTracker/Database/AbstractDatabaseTable.php
+++ b/src/JTracker/Database/AbstractDatabaseTable.php
@@ -341,10 +341,9 @@ class AbstractDatabaseTable implements \IteratorAggregate
 		// Delete the row by primary key.
 		$this->db->setQuery(
 			$this->db->getQuery(true)
-			->delete($this->db->quoteName($this->tableName))
-			->where($this->db->quoteName($key) . ' = ' . $this->db->quote($pKey))
-		)
-		->execute();
+				->delete($this->db->quoteName($this->tableName))
+				->where($this->db->quoteName($key) . ' = ' . $this->db->quote($pKey))
+		)->execute();
 
 		return $this;
 	}

--- a/src/JTracker/Github/GithubObject.php
+++ b/src/JTracker/Github/GithubObject.php
@@ -45,9 +45,7 @@ abstract class GithubObject extends JGithubObject
 			throw new GithubException($response);
 		}
 
-		$this->rateLimitRemaining = (isset($response->headers['X-RateLimit-Remaining']))
-			? $response->headers['X-RateLimit-Remaining']
-			: 0;
+		$this->rateLimitRemaining = (isset($response->headers['X-RateLimit-Remaining'])) ? $response->headers['X-RateLimit-Remaining'] : 0;
 
 		return $jsonDecode ? json_decode($response->body) : $response->body;
 	}
@@ -55,7 +53,7 @@ abstract class GithubObject extends JGithubObject
 	/**
 	 * Get the number of remaining requests.
 	 *
-	 * @return integer
+	 * @return  integer
 	 *
 	 * @since   1.0
 	 */

--- a/src/JTracker/Github/Package/Markdown.php
+++ b/src/JTracker/Github/Package/Markdown.php
@@ -54,7 +54,10 @@ class Markdown extends Package
 		$path = '/markdown';
 
 		// Build the request data.
-		$data = str_replace('\\/', '/', json_encode(
+		$data = str_replace(
+			'\\/',
+			'/',
+			json_encode(
 				array(
 					'text'    => $text,
 					'mode'    => $mode,

--- a/src/JTracker/Model/AbstractTrackerListModel.php
+++ b/src/JTracker/Model/AbstractTrackerListModel.php
@@ -288,7 +288,7 @@ abstract class AbstractTrackerListModel extends AbstractTrackerDatabaseModel
 	/**
 	 * Load the model state.
 	 *
-	 * @return  Registry  The state object.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */

--- a/src/JTracker/Service/ApplicationProvider.php
+++ b/src/JTracker/Service/ApplicationProvider.php
@@ -44,17 +44,19 @@ class ApplicationProvider implements ServiceProviderInterface
 	 *
 	 * @param   Container  $container  The DI container.
 	 *
-	 * @return  Container  Returns itself to support chaining.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
 	public function register(Container $container)
 	{
-		$container->set('app',
+		$container->share(
+			'app',
 			function ()
 			{
 				return $this->app;
-			}, true, true
+			},
+			true
 		);
 	}
 }

--- a/src/JTracker/Service/ConfigurationProvider.php
+++ b/src/JTracker/Service/ConfigurationProvider.php
@@ -71,17 +71,19 @@ class ConfigurationProvider implements ServiceProviderInterface
 	 *
 	 * @param   Container  $container  The DI container.
 	 *
-	 * @return  Container  Returns itself to support chaining.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
 	public function register(Container $container)
 	{
-		$container->set('config',
+		$container->share(
+			'config',
 			function ()
 			{
 				return $this->config;
-			}, true, true
+			},
+			true
 		);
 	}
 }

--- a/src/JTracker/Service/DatabaseProvider.php
+++ b/src/JTracker/Service/DatabaseProvider.php
@@ -27,14 +27,15 @@ class DatabaseProvider implements ServiceProviderInterface
 	 *
 	 * @param   Container  $container  The DI container.
 	 *
-	 * @return  Container  Returns itself to support chaining.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
 	public function register(Container $container)
 	{
-		$container->set('Joomla\\Database\\DatabaseDriver',
-			function () use ($container)
+		$container->share(
+			'Joomla\\Database\\DatabaseDriver',
+			function (Container $container)
 			{
 				$app = $container->get('app');
 
@@ -64,7 +65,8 @@ class DatabaseProvider implements ServiceProviderInterface
 				$db->setLogger($logger);
 
 				return $db;
-			}, true, true
+			},
+			true
 		);
 
 		// Alias the database

--- a/src/JTracker/Service/DebuggerProvider.php
+++ b/src/JTracker/Service/DebuggerProvider.php
@@ -25,18 +25,19 @@ class DebuggerProvider implements ServiceProviderInterface
 	 *
 	 * @param   Container  $container  The DI container.
 	 *
-	 * @return  Container  Returns itself to support chaining.
+	 * @return  void
 	 *
 	 * @since   1.0
-	 * @throws  \RuntimeException
 	 */
 	public function register(Container $container)
 	{
-		$container->set('App\\Debug\\TrackerDebugger',
-			function () use ($container)
+		$container->share(
+			'App\\Debug\\TrackerDebugger',
+			function (Container $container)
 			{
 				return new TrackerDebugger($container);
-			}, true, true
+			},
+			true
 		);
 
 		// Alias the object

--- a/src/JTracker/Service/GitHubProvider.php
+++ b/src/JTracker/Service/GitHubProvider.php
@@ -25,19 +25,21 @@ class GitHubProvider implements ServiceProviderInterface
 	 *
 	 * @param   Container  $container  The DI container.
 	 *
-	 * @return  Container  Returns the container to support chaining.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
 	public function register(Container $container)
 	{
-		$container->share('JTracker\\Github\\Github',
-			function () use ($container)
+		$container->share(
+			'JTracker\\Github\\Github',
+			function (Container $container)
 			{
 				// Call the Github factory's getInstance method and inject the application; it handles the rest of the configuration
 				return GithubFactory::getInstance($container->get('app'));
-			}, true
+			},
+			true
 		);
 
 		// Alias the object

--- a/src/JTracker/Service/TransifexProvider.php
+++ b/src/JTracker/Service/TransifexProvider.php
@@ -26,15 +26,16 @@ class TransifexProvider implements ServiceProviderInterface
 	 *
 	 * @param   Container  $container  The DI container.
 	 *
-	 * @return  Container  Returns the container to support chaining.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
 	public function register(Container $container)
 	{
-		return $container->set('BabDev\\Transifex\\Transifex',
-			function () use ($container)
+		return $container->share(
+			'BabDev\\Transifex\\Transifex',
+			function (Container $container)
 			{
 				$options = new Registry;
 
@@ -46,7 +47,8 @@ class TransifexProvider implements ServiceProviderInterface
 
 				// Instantiate Transifex
 				return new Transifex($options);
-			}
+			},
+			true
 		)->alias('transifex', 'BabDev\\Transifex\\Transifex');
 	}
 }


### PR DESCRIPTION
PHPCS v2 is generally a bit more strict and a bit better at catching errors.  While testing the Joomla Coding Standard with that version of PHPCS, the tracker throws a lot of errors on the v2 code base.  All of these are things that aren't really covered in the code standard explicitly but at least make our code consistent with how we handle things.  There's still a lot of stuff that we either need to address in the PHPCS sniffs, but this covers a good chunk of the logical stuff.