### PR TITLE
Add Replace environment variables in configuration

### DIFF
--- a/src/JTracker/Service/ConfigurationProvider.php
+++ b/src/JTracker/Service/ConfigurationProvider.php
@@ -52,7 +52,7 @@ class ConfigurationProvider implements ServiceProviderInterface
 		}
 
 		// Load the configuration file into an object.
-		$configObject = json_decode(file_get_contents($file));
+		$configObject = json_decode($this->replaceEnvVars(file_get_contents($file)));
 
 		if ($configObject === null)
 		{
@@ -83,5 +83,27 @@ class ConfigurationProvider implements ServiceProviderInterface
 				return $this->config;
 			}, true, true
 		);
+	}
+
+	/**
+	 * Replace any env vars referenced in a string with their values.
+	 *
+	 * @param   string  $string  The string to replace.
+	 *
+	 * @return  string
+	 *
+	 * @since  1.0
+	 */
+	private function replaceEnvVars($string)
+	{
+		foreach (array_keys($_ENV) as $var)
+		{
+			if (strstr($string, '$' . $var))
+			{
+				$string = str_replace('$' . $var, $_ENV[$var], $string);
+			}
+		}
+
+		return $string;
 	}
 }


### PR DESCRIPTION
This will replace environment variables from the system in the configuration.

It is used in the openshift branch like this: https://github.com/joomla/jissues/blob/openshift/etc/config.openshift.json

(see also: [jissues/openshift/docs#environment-variables](https://github.com/joomla/jissues/blob/openshift/Documentation/Development/Openshift.md#environment-variables))

But I think this might be useful also for other environments.