### PR TITLE
Implement a ProjectAwareTrait

### DIFF
--- a/src/App/Groups/Controller/Groups.php
+++ b/src/App/Groups/Controller/Groups.php
@@ -50,7 +50,7 @@ class Groups extends AbstractTrackerController
 
 		$this->getContainer()->get('app')->getUser()->authorize('manage');
 
-			$this->model->setProject($this->getContainer()->get('app')->getProject());
+		$this->model->setProject($this->getContainer()->get('app')->getProject());
 		$this->view->setProject($this->getContainer()->get('app')->getProject());
 
 		return $this;

--- a/src/App/Projects/ProjectAwareTrait.php
+++ b/src/App/Projects/ProjectAwareTrait.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Projects Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Projects;
+
+/**
+ * Decorator for an object which is aware of a TrackerProject instance
+ *
+ * @since  1.0
+ */
+trait ProjectAwareTrait
+{
+	/**
+	 * Project object
+	 *
+	 * @var    TrackerProject
+	 * @since  1.0
+	 */
+	private $project;
+
+	/**
+	 * Get the project.
+	 *
+	 * @return  TrackerProject
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function getProject()
+	{
+		if ($this->project)
+		{
+			return $this->project;
+		}
+
+		throw new \UnexpectedValueException('Project not set in ' . __CLASS__);
+	}
+
+	/**
+	 * Set the project.
+	 *
+	 * @param   TrackerProject  $project  The project.
+	 *
+	 * @return  $this
+	 *
+	 * @since   1.0
+	 */
+	public function setProject(TrackerProject $project)
+	{
+		$this->project = $project;
+
+		return $this;
+	}
+}

--- a/src/App/Tracker/Controller/AbstractHookController.php
+++ b/src/App/Tracker/Controller/AbstractHookController.php
@@ -160,6 +160,7 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 	 * @return  void
 	 *
 	 * @since   1.0
+	 * @todo    Should this be a TrackerProject object?
 	 */
 	protected function getProjectData()
 	{

--- a/src/App/Tracker/Model/IssuesModel.php
+++ b/src/App/Tracker/Model/IssuesModel.php
@@ -8,8 +8,6 @@
 
 namespace App\Tracker\Model;
 
-use App\Projects\TrackerProject;
-
 use Joomla\Database\DatabaseQuery;
 use Joomla\String\StringHelper;
 
@@ -30,48 +28,6 @@ class IssuesModel extends AbstractTrackerListModel
 	 * @since  1.0
 	 */
 	protected $context = 'tracker.issues';
-
-	/**
-	 * Project object
-	 *
-	 * @var    TrackerProject
-	 * @since  1.0
-	 */
-	protected $project = null;
-
-	/**
-	 * Get the project.
-	 *
-	 * @return  \App\Projects\TrackerProject
-	 *
-	 * @since   1.0
-	 * @throws  \RuntimeException
-	 */
-	public function getProject()
-	{
-		if (is_null($this->project))
-		{
-			throw new \RuntimeException('Project not set');
-		}
-
-		return $this->project;
-	}
-
-	/**
-	 * Set the project.
-	 *
-	 * @param   TrackerProject  $project  The project.
-	 *
-	 * @return  $this  Method supports chaining
-	 *
-	 * @since   1.0
-	 */
-	public function setProject(TrackerProject $project)
-	{
-		$this->project = $project;
-
-		return $this;
-	}
 
 	/**
 	 * Method to get a DatabaseQuery object for retrieving the data set from a database.

--- a/src/App/Tracker/View/Categories/CategoriesHtmlView.php
+++ b/src/App/Tracker/View/Categories/CategoriesHtmlView.php
@@ -8,10 +8,8 @@
 
 namespace App\Tracker\View\Categories;
 
-
 use JTracker\View\AbstractTrackerHtmlView;
 use App\Tracker\Model\CategoriesModel;
-use App\Projects\TrackerProject;
 
 /**
  * The category list view
@@ -27,14 +25,6 @@ class CategoriesHtmlView extends AbstractTrackerHtmlView
 	 * @since   1.0
 	 */
 	protected $model;
-
-	/**
-	 * Project object
-	 *
-	 * @var    TrackerProject
-	 * @since  1.0
-	 */
-	protected $project = null;
 
 	/**
 	 * Method to render the view.
@@ -53,39 +43,5 @@ class CategoriesHtmlView extends AbstractTrackerHtmlView
 		$this->renderer->set('project', $this->getProject());
 
 		return parent::render();
-	}
-
-	/**
-	 * Get the project.
-	 *
-	 * @return  TrackerProject
-	 *
-	 * @throws  \RuntimeException
-	 * @since   1.0
-	 */
-	public function getProject()
-	{
-		if (is_null($this->project))
-		{
-			throw new \RuntimeException('No project set.');
-		}
-
-		return $this->project;
-	}
-
-	/**
-	 * Set the project.
-	 *
-	 * @param   TrackerProject  $project  The project.
-	 *
-	 * @return  $this  Method allows chaining
-	 *
-	 * @since   1.0
-	 */
-	public function setProject(TrackerProject $project)
-	{
-		$this->project = $project;
-
-		return $this;
 	}
 }

--- a/src/App/Tracker/View/Category/CategoryHtmlView.php
+++ b/src/App/Tracker/View/Category/CategoryHtmlView.php
@@ -8,10 +8,8 @@
 
 namespace App\Tracker\View\Category;
 
-
 use JTracker\View\AbstractTrackerHtmlView;
 use App\Tracker\Model\CategoryModel;
-use App\Projects\TrackerProject;
 use App\Tracker\Table\CategoryTable;
 
 /**
@@ -28,14 +26,6 @@ class CategoryHtmlView extends AbstractTrackerHtmlView
 	 * @since   1.0
 	 */
 	protected $model;
-
-	/**
-	 * Project object
-	 *
-	 * @var    TrackerProject
-	 * @since  1.0
-	 */
-	protected $project = null;
 
 	/**
 	 * Item object
@@ -98,40 +88,5 @@ class CategoryHtmlView extends AbstractTrackerHtmlView
 		$this->renderer->set('item', $this->getItem());
 
 		return parent::render();
-	}
-
-	/**
-	 * Get the project.
-	 *
-	 * @return  TrackerProject
-	 *
-	 * @throws  \RuntimeException
-	 *
-	 * @since   1.0
-	 */
-	public function getProject()
-	{
-		if (is_null($this->project))
-		{
-			throw new \RuntimeException('No project set.');
-		}
-
-		return $this->project;
-	}
-
-	/**
-	 * Set the project.
-	 *
-	 * @param   TrackerProject  $project  The project.
-	 *
-	 * @return  $this  Method allows chaining
-	 *
-	 * @since   1.0
-	 */
-	public function setProject(TrackerProject $project)
-	{
-		$this->project = $project;
-
-		return $this;
 	}
 }

--- a/src/App/Tracker/View/Issue/IssueHtmlView.php
+++ b/src/App/Tracker/View/Issue/IssueHtmlView.php
@@ -8,7 +8,6 @@
 
 namespace App\Tracker\View\Issue;
 
-use App\Projects\TrackerProject;
 use App\Tracker\Model\IssueModel;
 use App\Tracker\Table\IssuesTable;
 
@@ -28,14 +27,6 @@ class IssueHtmlView extends AbstractTrackerHtmlView
 	 * @since   1.0
 	 */
 	protected $model;
-
-	/**
-	 * Project object
-	 *
-	 * @var    TrackerProject
-	 * @since  1.0
-	 */
-	protected $project = null;
 
 	/**
 	 * Item object
@@ -69,40 +60,6 @@ class IssueHtmlView extends AbstractTrackerHtmlView
 		$this->renderer->set('canEditOwn', $this->canEditOwn());
 
 		return parent::render();
-	}
-
-	/**
-	 * Get the project.
-	 *
-	 * @return  TrackerProject
-	 *
-	 * @since   1.0
-	 * @throws  \RuntimeException
-	 */
-	public function getProject()
-	{
-		if (is_null($this->project))
-		{
-			throw new \RuntimeException('No project set.');
-		}
-
-		return $this->project;
-	}
-
-	/**
-	 * Set the project.
-	 *
-	 * @param   TrackerProject  $project  The project.
-	 *
-	 * @return  $this  Method allows chaining
-	 *
-	 * @since   1.0
-	 */
-	public function setProject(TrackerProject $project)
-	{
-		$this->project = $project;
-
-		return $this;
 	}
 
 	/**

--- a/src/App/Tracker/View/Issues/IssuesHtmlView.php
+++ b/src/App/Tracker/View/Issues/IssuesHtmlView.php
@@ -8,7 +8,6 @@
 
 namespace App\Tracker\View\Issues;
 
-use App\Projects\TrackerProject;
 use App\Tracker\Model\IssuesModel;
 
 use JTracker\View\AbstractTrackerHtmlView;
@@ -29,14 +28,6 @@ class IssuesHtmlView extends AbstractTrackerHtmlView
 	protected $model;
 
 	/**
-	 * Project object
-	 *
-	 * @var    TrackerProject
-	 * @since  1.0
-	 */
-	protected $project = null;
-
-	/**
 	 * Method to render the view.
 	 *
 	 * @return  string  The rendered view.
@@ -51,39 +42,5 @@ class IssuesHtmlView extends AbstractTrackerHtmlView
 		$this->renderer->set('project', $this->getProject());
 
 		return parent::render();
-	}
-
-	/**
-	 * Get the project.
-	 *
-	 * @return  TrackerProject
-	 *
-	 * @since   1.0
-	 * @throws  \RuntimeException
-	 */
-	public function getProject()
-	{
-		if (is_null($this->project))
-		{
-			throw new \RuntimeException('No project set.');
-		}
-
-		return $this->project;
-	}
-
-	/**
-	 * Set the project.
-	 *
-	 * @param   TrackerProject  $project  The project.
-	 *
-	 * @return  $this  Method allows chaining
-	 *
-	 * @since   1.0
-	 */
-	public function setProject(TrackerProject $project)
-	{
-		$this->project = $project;
-
-		return $this;
 	}
 }

--- a/src/App/Users/Model/UserModel.php
+++ b/src/App/Users/Model/UserModel.php
@@ -8,8 +8,6 @@
 
 namespace App\Users\Model;
 
-use App\Projects\TrackerProject;
-
 use Joomla\Filter\InputFilter;
 
 use JTracker\Authentication\GitHub\GitHubUser;
@@ -24,14 +22,6 @@ use JTracker\Model\AbstractTrackerDatabaseModel;
 class UserModel extends AbstractTrackerDatabaseModel
 {
 	/**
-	 * Project object
-	 *
-	 * @var    TrackerProject
-	 * @since  1.0
-	 */
-	protected $project;
-
-	/**
 	 * Get an item.
 	 *
 	 * @param   integer  $itemId  The item id.
@@ -45,12 +35,12 @@ class UserModel extends AbstractTrackerDatabaseModel
 	{
 		try
 		{
-			$user = new GitHubUser($this->project, $this->db, $itemId);
+			$user = new GitHubUser($this->getProject(), $this->db, $itemId);
 		}
 		catch (\RuntimeException $e)
 		{
 			// Load a blank user
-			$user = new GitHubUser($this->project, $this->db);
+			$user = new GitHubUser($this->getProject(), $this->db);
 		}
 
 		return $user;
@@ -82,22 +72,6 @@ class UserModel extends AbstractTrackerDatabaseModel
 		$data['params'] = json_encode($src['params']);
 
 		(new TableUsers($this->db))->save($data);
-
-		return $this;
-	}
-
-	/**
-	 * Set the project.
-	 *
-	 * @param   TrackerProject  $project  The project.
-	 *
-	 * @return  $this  Method allows chaining
-	 *
-	 * @since   1.0
-	 */
-	public function setProject(TrackerProject $project)
-	{
-		$this->project = $project;
 
 		return $this;
 	}

--- a/src/JTracker/Authentication/User.php
+++ b/src/JTracker/Authentication/User.php
@@ -9,6 +9,7 @@
 namespace JTracker\Authentication;
 
 use App\Projects\ProjectAwareTrait;
+use App\Projects\TrackerProject;
 
 use Joomla\Database\DatabaseDriver;
 use Joomla\Date\Date;

--- a/src/JTracker/Authentication/User.php
+++ b/src/JTracker/Authentication/User.php
@@ -8,7 +8,7 @@
 
 namespace JTracker\Authentication;
 
-use App\Projects\TrackerProject;
+use App\Projects\ProjectAwareTrait;
 
 use Joomla\Database\DatabaseDriver;
 use Joomla\Date\Date;
@@ -24,6 +24,8 @@ use JTracker\Authentication\Exception\AuthenticationException;
  */
 abstract class User implements \Serializable
 {
+	use ProjectAwareTrait;
+
 	/**
 	 * Id.
 	 *
@@ -105,14 +107,6 @@ abstract class User implements \Serializable
 	protected $database = null;
 
 	/**
-	 * Project object
-	 *
-	 * @var    TrackerProject
-	 * @since  1.0
-	 */
-	protected $project = null;
-
-	/**
 	 * Constructor.
 	 *
 	 * @param   TrackerProject  $project     The tracker project.
@@ -124,7 +118,7 @@ abstract class User implements \Serializable
 	public function __construct(TrackerProject $project, DatabaseDriver $database, $identifier = 0)
 	{
 		$this->setDatabase($database);
-		$this->project  = $project;
+		$this->setProject($project);
 
 		// Create the user parameters object.
 		$this->params = new Registry;
@@ -323,7 +317,6 @@ abstract class User implements \Serializable
 			throw new \InvalidArgumentException('Undefined action: ' . $action);
 		}
 
-		/* @type \App\Projects\TrackerProject $project */
 		$project = $this->getProject();
 
 		if ($project->getAccessGroups($action, 'Public'))
@@ -408,24 +401,6 @@ abstract class User implements \Serializable
 	}
 
 	/**
-	 * Get the project.
-	 *
-	 * @return  \App\Projects\TrackerProject
-	 *
-	 * @since   1.0
-	 * @throws  \UnexpectedValueException
-	 */
-	public function getProject()
-	{
-		if (is_null($this->project))
-		{
-			throw new \UnexpectedValueException('Project not set.');
-		}
-
-		return $this->project;
-	}
-
-	/**
 	 * Method to set the database connector.
 	 *
 	 * @param   DatabaseDriver  $database  The Database connector.
@@ -437,22 +412,6 @@ abstract class User implements \Serializable
 	public function setDatabase(DatabaseDriver $database)
 	{
 		$this->database = $database;
-
-		return $this;
-	}
-
-	/**
-	 * Set the project object.
-	 *
-	 * @param   TrackerProject  $project  The project.
-	 *
-	 * @return  $this
-	 *
-	 * @since   1.0
-	 */
-	public function setProject(TrackerProject $project)
-	{
-		$this->project = $project;
 
 		return $this;
 	}

--- a/src/JTracker/Model/AbstractTrackerDatabaseModel.php
+++ b/src/JTracker/Model/AbstractTrackerDatabaseModel.php
@@ -8,7 +8,7 @@
 
 namespace JTracker\Model;
 
-use App\Projects\TrackerProject;
+use App\Projects\ProjectAwareTrait;
 
 use Joomla\Model\AbstractDatabaseModel;
 use Joomla\Database\DatabaseDriver;
@@ -22,6 +22,8 @@ use JTracker\Database\AbstractDatabaseTable;
  */
 abstract class AbstractTrackerDatabaseModel extends AbstractDatabaseModel
 {
+	use ProjectAwareTrait;
+
 	/**
 	 * The model (base) name
 	 *
@@ -45,14 +47,6 @@ abstract class AbstractTrackerDatabaseModel extends AbstractDatabaseModel
 	 * @since  1.0
 	 */
 	protected $table;
-
-	/**
-	 * Project object
-	 *
-	 * @var    TrackerProject
-	 * @since  1.0
-	 */
-	protected $project;
 
 	/**
 	 * Instantiate the model.
@@ -146,39 +140,5 @@ abstract class AbstractTrackerDatabaseModel extends AbstractDatabaseModel
 		$this->table = new $class($this->getDb());
 
 		return $this->table;
-	}
-
-	/**
-	 * Get the project.
-	 *
-	 * @return  TrackerProject
-	 *
-	 * @since   1.0
-	 * @throws  \UnexpectedValueException
-	 */
-	public function getProject()
-	{
-		if (is_null($this->project))
-		{
-			throw new \UnexpectedValueException('Project not set');
-		}
-
-		return $this->project;
-	}
-
-	/**
-	 * Set the project.
-	 *
-	 * @param   TrackerProject  $project  The project.
-	 *
-	 * @return  $this  Method allows chaining
-	 *
-	 * @since   1.0
-	 */
-	public function setProject(TrackerProject $project)
-	{
-		$this->project = $project;
-
-		return $this;
 	}
 }

--- a/src/JTracker/View/AbstractTrackerHtmlView.php
+++ b/src/JTracker/View/AbstractTrackerHtmlView.php
@@ -8,7 +8,7 @@
 
 namespace JTracker\View;
 
-use App\Projects\TrackerProject;
+use App\Projects\ProjectAwareTrait;
 
 use Joomla\Model\ModelInterface;
 use Joomla\View\AbstractView;
@@ -21,6 +21,8 @@ use Joomla\View\Renderer\RendererInterface;
  */
 abstract class AbstractTrackerHtmlView extends AbstractView
 {
+	use ProjectAwareTrait;
+
 	/**
 	 * The view layout.
 	 *
@@ -36,14 +38,6 @@ abstract class AbstractTrackerHtmlView extends AbstractView
 	 * @since  1.0
 	 */
 	protected $renderer = null;
-
-	/**
-	 * Project object
-	 *
-	 * @var    TrackerProject
-	 * @since  1.0
-	 */
-	protected $project;
 
 	/**
 	 * Method to instantiate the view.
@@ -138,40 +132,6 @@ abstract class AbstractTrackerHtmlView extends AbstractView
 	public function setLayout($layout)
 	{
 		$this->layout = $layout;
-
-		return $this;
-	}
-
-	/**
-	 * Get the project.
-	 *
-	 * @return  \App\Projects\TrackerProject
-	 *
-	 * @since   1.0
-	 * @throws  \UnexpectedValueException
-	 */
-	public function getProject()
-	{
-		if (is_null($this->project))
-		{
-			throw new \UnexpectedValueException('Project not set');
-		}
-
-		return $this->project;
-	}
-
-	/**
-	 * Set the project.
-	 *
-	 * @param   TrackerProject  $project  The project.
-	 *
-	 * @return  $this  Method supports chaining
-	 *
-	 * @since   1.0
-	 */
-	public function setProject(TrackerProject $project)
-	{
-		$this->project = $project;
 
 		return $this;
 	}


### PR DESCRIPTION
This PR adds a trait for classes which have a `TrackerProject` object injected into them to help cut back on some of the code duplication in repeating a `$project` class var and `getProject()` and `setProject()` methods.