### PR TITLE
JoomlacmsTestsListener

### DIFF
--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsTestsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsTestsListener.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Tracker Application
+ *
+ * @copyright  Copyright (C) 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Tracker\Controller\Hooks\Listeners;
+
+use App\Projects\TrackerProject;
+
+use Joomla\Event\Event;
+
+use JTracker\Github\DataType\Commit\Status;
+
+/**
+ * Event listener for the joomla-cms human tests events.
+ *
+ * @since  1.0
+ */
+class JoomlacmsTestsListener extends AbstractListener
+{
+	/**
+	 * Event for after test is submitted in the application.
+	 *
+	 * @param   Event  $event  The Event object.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function onTestAfterSubmit(Event $event)
+	{
+		// Pull the arguments array
+		$arguments = $event->getArguments();
+
+		$status = $this->getStatus($arguments['project'], $arguments['data']->testsSuccess, $arguments['data']->testsFailure, $arguments['issueNumber']);
+
+		$this->createStatus($arguments['github'], $arguments['project'], $arguments['issueNumber'], $status);
+	}
+
+	/**
+	 * Get a GitHub Status object.
+	 *
+	 * @param   TrackerProject  $project       The project object.
+	 * @param   array           $testsSuccess  Successful tests.
+	 * @param   array           $testsFailure  Failed tests.
+	 * @param   integer         $issueNumber   The issue number.
+	 *
+	 * @since   1.0
+	 * @return  Status
+	 */
+	private function getStatus(TrackerProject $project, array $testsSuccess, array $testsFailure, $issueNumber)
+	{
+		$status = new Status;
+
+		$successes = count($testsSuccess);
+		$failures = count($testsFailure);
+
+		if ($successes >= 2 && $failures == 0)
+		{
+			// 2 or more successes and 0 failures.
+			$status->state = 'success';
+		}
+		elseif ($successes == 0 && $failures >= 2)
+		{
+			// 0 successes and 2 or more failures.
+			$status->state = 'failure';
+		}
+		else
+		{
+			// Everything else.
+			$status->state = 'pending';
+		}
+
+		$status->description = sprintf(
+			'Human Test Results: %1$d Successful %2$d Failed.', $successes, $failures
+		);
+
+		$status->context = 'JTracker/HumanTestResults';
+
+		$targetBaseUrl = 'http://issues.joomla.org';
+
+		$status->targetUrl = $targetBaseUrl . '/tracker/' . $project->alias . '/' . $issueNumber;
+
+		return $status;
+	}
+}

--- a/src/App/Tracker/Controller/TestResult/Ajax/Alter.php
+++ b/src/App/Tracker/Controller/TestResult/Ajax/Alter.php
@@ -8,10 +8,12 @@
 
 namespace App\Tracker\Controller\TestResult\Ajax;
 
+use App\Projects\TrackerProject;
 use App\Tracker\Model\ActivityModel;
 use App\Tracker\Model\IssueModel;
 
 use JTracker\Controller\AbstractAjaxController;
+use JTracker\Github\GithubFactory;
 
 /**
  * Alter test result controller class.
@@ -47,6 +49,10 @@ class Alter extends AbstractAjaxController
 			throw new \Exception('No issue ID received.');
 		}
 
+		$this->dispatcher = $application->getDispatcher();
+		$this->addEventListener('tests');
+		$this->setProjectGitHubBot($project);
+
 		$data   = new \stdClass;
 		$result = new \stdClass;
 
@@ -58,12 +64,16 @@ class Alter extends AbstractAjaxController
 		$data->testResults = $issueModel
 			->saveTest($issueId, $result->user, $result->value);
 
+		$issueNumber = $issueModel->getIssueNumberById($issueId);
+
 		$event = (new ActivityModel($this->getContainer()->get('db')))
 			->addActivityEvent(
 				'alter_testresult', 'now', $user->username,
-				$project->project_id, $issueModel->getIssueNumberById($issueId), null,
+				$project->project_id, $issueNumber, null,
 				json_encode($result)
 			);
+
+		$this->triggerEvent('onTestAfterSubmit', ['issueNumber' => $issueNumber, 'data' => $data->testResults]);
 
 		$data->event = new \stdClass;
 
@@ -77,5 +87,33 @@ class Alter extends AbstractAjaxController
 		$this->response->data = json_encode($data);
 
 		$this->response->message = g11n3t('Test successfully added');
+	}
+
+	/**
+	 * Set the GitHub object with the credentials from the project or,
+	 * if not found, with those from the configuration file.
+	 *
+	 * @param   TrackerProject  $project  The Project object.
+	 *
+	 * @since   1.0
+	 * @return $this
+	 */
+	protected function setProjectGitHubBot(TrackerProject $project)
+	{
+		// If there is a bot defined for the project, prefer it over the config credentials.
+		if ($project->gh_editbot_user && $project->gh_editbot_pass)
+		{
+			$this->github = GithubFactory::getInstance(
+				$this->getContainer()->get('app'), true, $project->gh_editbot_user, $project->gh_editbot_pass
+			);
+		}
+		else
+		{
+			$this->github = GithubFactory::getInstance(
+				$this->getContainer()->get('app')
+			);
+		}
+
+		return $this;
 	}
 }

--- a/src/App/Tracker/Controller/TestResult/Ajax/Submit.php
+++ b/src/App/Tracker/Controller/TestResult/Ajax/Submit.php
@@ -8,10 +8,12 @@
 
 namespace App\Tracker\Controller\TestResult\Ajax;
 
+use App\Projects\TrackerProject;
 use App\Tracker\Model\ActivityModel;
 use App\Tracker\Model\IssueModel;
 
 use JTracker\Controller\AbstractAjaxController;
+use JTracker\Github\GithubFactory;
 
 /**
  * Add test result controller class.
@@ -48,18 +50,27 @@ class Submit extends AbstractAjaxController
 			throw new \Exception('No issue ID received.');
 		}
 
+		$this->dispatcher = $application->getDispatcher();
+		$this->addEventListener('tests');
+
+		$this->setProjectGitHubBot($project);
+
 		$issueModel = new IssueModel($this->getContainer()->get('db'));
 
 		$data = new \stdClass;
 
 		$data->testResults = $issueModel->saveTest($issueId, $user->username, $result);
 
+		$issueNumber = $issueModel->getIssueNumberById($issueId);
+
 		$event = (new ActivityModel($this->getContainer()->get('db')))
 			->addActivityEvent(
 				'test_item', 'now', $user->username,
-				$project->project_id, $issueModel->getIssueNumberById($issueId), null,
+				$project->project_id, $issueNumber, null,
 				json_encode($result)
 			);
+
+		$this->triggerEvent('onTestAfterSubmit', ['issueNumber' => $issueNumber, 'data' => $data->testResults]);
 
 		$data->event = new \stdClass;
 
@@ -73,5 +84,33 @@ class Submit extends AbstractAjaxController
 		$this->response->data = json_encode($data);
 
 		$this->response->message = g11n3t('Test successfully added');
+	}
+
+	/**
+	 * Set the GitHub object with the credentials from the project or,
+	 * if not found, with those from the configuration file.
+	 *
+	 * @param   TrackerProject  $project  The Project object.
+	 *
+	 * @since   1.0
+	 * @return $this
+	 */
+	protected function setProjectGitHubBot(TrackerProject $project)
+	{
+		// If there is a bot defined for the project, prefer it over the config credentials.
+		if ($project->gh_editbot_user && $project->gh_editbot_pass)
+		{
+			$this->github = GithubFactory::getInstance(
+				$this->getContainer()->get('app'), true, $project->gh_editbot_user, $project->gh_editbot_pass
+			);
+		}
+		else
+		{
+			$this->github = GithubFactory::getInstance(
+				$this->getContainer()->get('app')
+			);
+		}
+
+		return $this;
 	}
 }


### PR DESCRIPTION
This will add an `onTestAfterSubmit` event and a `JoomlacmsTestsListener` event listener that will create a status on GitHub whenever a test is submitted (or altered) on jissues.

FYI GitHub statuses are those annoying messages that appear for "external services" like Travis.

In our case this would reflect the test results (from JBS) to the GitHub UI along with the Travis (or other) test results.

Example:

![usr-tests](https://cloud.githubusercontent.com/assets/33978/9281231/28b282d6-4289-11e5-863c-ccfffbaf8113.png)

The text that appears is fully customizable for every project and  I would beg you to postpone discussions about the wording after and only if this PR has been merged - thanks :wink: 

Depends on #694, closes #596