### PR TITLE
JoomlacmsItemsListener

### DIFF
--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsItemsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsItemsListener.php
@@ -15,14 +15,14 @@ use Joomla\Github\Github;
 use Monolog\Logger;
 
 /**
- * Event listener for the joomla-cms Comments request hook
+ * Event listener for the joomla-cms Item events.
  *
  * @since  1.0
  */
-class JoomlacmsCommentsListener extends AbstractListener
+class JoomlacmsItemsListener extends AbstractListener
 {
 	/**
-	 * Event for after Comments gets added to the Tracker
+	 * Event for after item gets updated on the Tracker.
 	 *
 	 * @param   Event  $event  Event object
 	 *
@@ -30,17 +30,17 @@ class JoomlacmsCommentsListener extends AbstractListener
 	 *
 	 * @since   1.0
 	 */
-	public function onCommentAfterCreate(Event $event)
+	public function onItemAfterSave(Event $event)
 	{
 		// Pull the arguments array
 		$arguments = $event->getArguments();
 
 		// Add a RTC label if the item is in that status
-		$this->checkRTClabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
+		$this->checkRTClabel($arguments['data'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
 	}
 
 	/**
-	 * Event for after Comments requests are updated in the application
+	 * Event for after new item requests are submitted in the application.
 	 *
 	 * @param   Event  $event  Event object
 	 *
@@ -48,13 +48,13 @@ class JoomlacmsCommentsListener extends AbstractListener
 	 *
 	 * @since   1.0
 	 */
-	public function onCommentAfterUpdate(Event $event)
+	public function onItemAfterSubmit(Event $event)
 	{
 		// Pull the arguments array
 		$arguments = $event->getArguments();
 
-		// Add a RTC label if the item is in that status
-		$this->checkRTClabel($arguments['hookData'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
+		// New items can't have the RTC status.
+		// Disabled $this->checkRTClabel($arguments['data'], $arguments['github'], $arguments['logger'], $arguments['project'], $arguments['table']);
 	}
 
 	/**

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -8,9 +8,11 @@
 
 namespace App\Tracker\Controller\Issue;
 
+use App\Projects\TrackerProject;
 use App\Tracker\Model\CategoryModel;
 use App\Tracker\Model\IssueModel;
 use App\Tracker\Table\ActivitiesTable;
+use App\Tracker\Table\IssuesTable;
 
 use Joomla\Date\Date;
 
@@ -55,6 +57,9 @@ class Save extends AbstractTrackerController
 		{
 			throw new \UnexpectedValueException('No issue number received.');
 		}
+
+		$this->dispatcher = $application->getDispatcher();
+		$this->addEventListener('items');
 
 		$item = $model->getItem($issueNumber);
 
@@ -281,6 +286,21 @@ class Save extends AbstractTrackerController
 
 				$table->store();
 			}
+
+			// Process save events
+			$this->setProjectGitHubBot($project);
+
+			$data = new \stdClass;
+			$data->issue = new \stdClass;
+			$data->issue->number = $issueNumber;
+
+			$table = (new IssuesTable($this->getContainer()->get('db')))
+				->load(['project_id' => $project->getProject_Id(), 'issue_number' => $issueNumber]);
+
+			$this->triggerEvent(
+				'onItemAfterSave',
+				['issueNumber' => $issueNumber, 'data' => $data, 'table' => $table]
+			);
 
 			$application->enqueueMessage('The changes have been saved.', 'success')
 				->redirect(
@@ -521,5 +541,33 @@ class Save extends AbstractTrackerController
 		}
 
 		return $gitHubResponse;
+	}
+
+	/**
+	 * Set the GitHub object with the credentials from the project or,
+	 * if not found, with those from the configuration file.
+	 *
+	 * @param   TrackerProject  $project  The Project object.
+	 *
+	 * @since   1.0
+	 * @return $this
+	 */
+	protected function setProjectGitHubBot(TrackerProject $project)
+	{
+		// If there is a bot defined for the project, prefer it over the config credentials.
+		if ($project->gh_editbot_user && $project->gh_editbot_pass)
+		{
+			$this->github = GithubFactory::getInstance(
+				$this->getContainer()->get('app'), true, $project->gh_editbot_user, $project->gh_editbot_pass
+			);
+		}
+		else
+		{
+			$this->github = GithubFactory::getInstance(
+				$this->getContainer()->get('app')
+			);
+		}
+
+		return $this;
 	}
 }

--- a/src/App/Tracker/Controller/Issue/Submit.php
+++ b/src/App/Tracker/Controller/Issue/Submit.php
@@ -8,8 +8,10 @@
 
 namespace App\Tracker\Controller\Issue;
 
+use App\Projects\TrackerProject;
 use App\Tracker\Model\CategoryModel;
 use App\Tracker\Model\IssueModel;
+use App\Tracker\Table\IssuesTable;
 
 use Joomla\Date\Date;
 
@@ -52,6 +54,9 @@ class Submit extends AbstractTrackerController
 		{
 			throw new \RuntimeException('No body received.');
 		}
+
+		$this->dispatcher = $application->getDispatcher();
+		$this->addEventListener('items');
 
 		// Prepare issue for the store
 		$data = array();
@@ -170,11 +175,28 @@ class Submit extends AbstractTrackerController
 			);
 		}
 
+		// Process save events
+		$this->setProjectGitHubBot($project);
+
+		$issueNumber = $data['issue_number'];
+
+		$data = new \stdClass;
+		$data->issue = new \stdClass;
+		$data->issue->number = $issueNumber;
+
+		$table = (new IssuesTable($this->getContainer()->get('db')))
+			->load(['project_id' => $project->getProject_Id(), 'issue_number' => $issueNumber]);
+
+		$this->triggerEvent(
+			'onItemAfterSubmit',
+			['issueNumber' => $issueNumber, 'data' => $data, 'table' => $table]
+		);
+
 		$application->enqueueMessage(g11n3t('Your report has been submitted.'), 'success');
 
 		$application->redirect(
 			$application->get('uri.base.path')
-			. 'tracker/' . $project->alias . '/' . $data['number']
+			. 'tracker/' . $project->alias . '/' . $issueNumber
 		);
 
 		return;
@@ -266,5 +288,33 @@ class Submit extends AbstractTrackerController
 		}
 
 		return $gitHubResponse;
+	}
+
+	/**
+	 * Set the GitHub object with the credentials from the project or,
+	 * if not found, with those from the configuration file.
+	 *
+	 * @param   TrackerProject  $project  The Project object.
+	 *
+	 * @since   1.0
+	 * @return $this
+	 */
+	protected function setProjectGitHubBot(TrackerProject $project)
+	{
+		// If there is a bot defined for the project, prefer it over the config credentials.
+		if ($project->gh_editbot_user && $project->gh_editbot_pass)
+		{
+			$this->github = GithubFactory::getInstance(
+				$this->getContainer()->get('app'), true, $project->gh_editbot_user, $project->gh_editbot_pass
+			);
+		}
+		else
+		{
+			$this->github = GithubFactory::getInstance(
+				$this->getContainer()->get('app')
+			);
+		}
+
+		return $this;
 	}
 }


### PR DESCRIPTION
As discussed here: https://github.com/joomla/jissues/pull/692#issuecomment-129461996

This will add 
- an `onItemAfterSave` and an `onItemAfterSubmit` event
- a `JoomlacmsItemsListener` event listener

Note that this will modify the feature added in #667.
It should be possible now to have changes to an item reflected to GitHub without the need for a comment :wink: 

To test 
- change the status for an issue to 'RTC' while editing on jissues
- check that the 'RTC' label is added to the issue on GitHub.

Obviously JBS testing depends on previous merging and deploying...  

Depends on #694.
