### PR TITLE
Add the 4 weeks to the no desc message

### DIFF
--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -567,7 +567,7 @@ class JoomlacmsPullsListener extends AbstractListener
 					$project->gh_user,
 					$project->gh_project,
 					$hookData->pull_request->number,
-					'Please add more information to your issue. Without test instructions and/or any description we will close this issue soon. Thanks.'
+					'Please add more information to your issue. Without test instructions and/or any description we will close this issue within 4 weeks. Thanks.'
 					. $appNote
 				);
 


### PR DESCRIPTION
This just replaces `soon` with `within 4 weeks` on the `Test instructions missing` Message.

The 4 weeks are also in the default textes for PBF events (can be found here: http://br.joomlapbf.com/). Thanks for the tip @roland-d 