### PR TITLE
Add support for PDF, txt, xlsx, docx and pptx as github

### DIFF
--- a/etc/config.dist.json
+++ b/etc/config.dist.json
@@ -86,7 +86,14 @@
 
 	"validation": {
 		"mime_types": [
-			"image/png", "image/jpeg", "image/gif"
+			"image/png",
+			"image/jpeg",
+			"image/gif",
+			"application/pdf",
+			"text/plain",
+			"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+			"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+			"application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 		],
 		"file_size" : "1M"
 	}


### PR DESCRIPTION
As Github adds support for pdf, txt, xlsx, docx and pptx we can follow? see: https://github.com/blog/2061-attach-files-to-comments

Mime Types based on: http://www.freeformatter.com/mime-types-list.html

Maybe just only pdf and txt without the microsoft types?