### PR TITLE
Lets PLT / Manager use Milestones and Labels from issues.joomla.org ;)

### DIFF
--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -67,7 +67,7 @@ class Save extends AbstractTrackerController
 			$data = $src;
 
 			// Allow admins to update labels and milestones
-			if (!$user->check('admin'))
+			if (!$user->check('manage'))
 			{
 				if (!empty($item->labels))
 				{
@@ -358,7 +358,7 @@ class Save extends AbstractTrackerController
 			);
 
 			$needUpdate = false;
-			$isAllowed  = $application->getUser()->check('admin');
+			$isAllowed  = $application->getUser()->check('manage');
 
 			// The milestone and labels are silently dropped,
 			// so try to update the milestone and/or labels if they are not set.

--- a/templates/tracker/issue.add.twig
+++ b/templates/tracker/issue.add.twig
@@ -68,7 +68,7 @@
                     </div>
                 {% endif %}
 
-                {% if user.check('admin') %}
+                {% if user.check('manage') %}
 
                     {% if project.labels %}
                         {{ fields.label('labels', 'Labels'|_) }}

--- a/templates/tracker/issue.edit.twig
+++ b/templates/tracker/issue.edit.twig
@@ -151,7 +151,7 @@
                 </li>
             {% endif %}
 
-            {% if user.check('admin') %}
+            {% if user.check('manage') %}
 
                 {% if project.labels %}
                     <li>


### PR DESCRIPTION
Some days bevor i was thinking PLT acion is `admin` but since i'm in the same Group as the other PLT Memebers i notice the they have the action `manage` and the `admin` is something more higher. ;)

But i guess we can allow the using of labels and milestones to the PLT and me as well until they don't decide different. :)