### PR TITLE
Reset the test after pull update

### DIFF
--- a/cli/Application/Command/Get/Project/Issues.php
+++ b/cli/Application/Command/Get/Project/Issues.php
@@ -345,6 +345,29 @@ class Issues extends Project
 						$gitHubBot->addComment(
 							$this->project, $table->issue_number, $comment, $this->project->gh_editbot_user, $this->getContainer()->get('db')
 						);
+
+						// Reset the tests
+						foreach($testers as $tester)
+						{
+							$result = new \stdClass;
+							$result->user  = $tester;
+							$result->value = '0';
+
+							// Add the Activity Entry
+							$this->addActivityEvent(
+								'alter_testresult',
+								'now',
+								$this->project->gh_editbot_user,
+								$this->project->project_id,
+								$this->data->number,
+								null,
+								json_encode($result)
+							);
+
+							// Reset the tests to zero
+							$restTests = (new IssueModel($this->getContainer()->get('db')))
+								->resetTests($table->id, $tester);
+						}
 					}
 				}
 

--- a/cli/Application/Command/Get/Project/Issues.php
+++ b/cli/Application/Command/Get/Project/Issues.php
@@ -347,7 +347,7 @@ class Issues extends Project
 						);
 
 						// Reset the tests
-						foreach($testers as $tester)
+						foreach ($testers as $tester)
 						{
 							$result = new \stdClass;
 							$result->user  = $tester;

--- a/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
@@ -327,6 +327,11 @@ class ReceivePullsHook extends AbstractHookController
 				$gitHubBot->addComment(
 					$this->project, $table->issue_number, $comment, $this->project->gh_editbot_user, $this->getContainer()->get('db')
 				);
+
+				// Reset the tests to zero
+				$testers = (new IssueModel($this->getContainer()->get('db')))
+					->resetAllTests($table->id);
+
 			}
 		}
 

--- a/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
@@ -328,10 +328,28 @@ class ReceivePullsHook extends AbstractHookController
 					$this->project, $table->issue_number, $comment, $this->project->gh_editbot_user, $this->getContainer()->get('db')
 				);
 
-				// Reset the tests to zero
-				$testers = (new IssueModel($this->getContainer()->get('db')))
-					->resetAllTests($table->id);
+				// Reset the tests
+				foreach($testers as $tester)
+				{
+					$result = new \stdClass;
+					$result->user  = $tester;
+					$result->value = '0';
 
+					// Add the Activity Entry
+					$this->addActivityEvent(
+						'alter_testresult',
+						'now',
+						$this->project->gh_editbot_user,
+						$this->project->project_id,
+						$this->data->number,
+						null,
+						json_encode($result)
+					);
+
+					// Reset the tests to zero
+					$restTests = (new IssueModel($this->getContainer()->get('db')))
+						->resetTests($table->id, $tester);
+				}
 			}
 		}
 

--- a/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
@@ -329,7 +329,7 @@ class ReceivePullsHook extends AbstractHookController
 				);
 
 				// Reset the tests
-				foreach($testers as $tester)
+				foreach ($testers as $tester)
 				{
 					$result = new \stdClass;
 					$result->user  = $tester;

--- a/src/App/Tracker/Model/IssueModel.php
+++ b/src/App/Tracker/Model/IssueModel.php
@@ -301,7 +301,8 @@ class IssueModel extends AbstractTrackerDatabaseModel
 	/**
 	 * Reset all user tests for a PR.
 	 *
-	 * @param   integer  $itemId  The issue ID.
+	 * @param   integer  $itemId    The issue ID.
+	 * @param   string   $username  The username that test should be removed.
 	 *
 	 * @return  void
 	 *

--- a/src/App/Tracker/Model/IssueModel.php
+++ b/src/App/Tracker/Model/IssueModel.php
@@ -299,6 +299,26 @@ class IssueModel extends AbstractTrackerDatabaseModel
 	}
 
 	/**
+	 * Reset all user tests for a PR.
+	 *
+	 * @param   integer  $itemId  The issue ID.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function resetTests($itemId, $username)
+	{
+		$this->db->setQuery(
+			$this->db->getQuery(true)
+				->delete('*')
+				->from($this->db->quoteName('#__issues_tests'))
+				->where($this->db->quoteName('item_id') . ' = ' . (int) $itemId)
+				->where($this->db->quoteName('username') . ' = ' . (int) $username)
+		)->execute();
+	}
+
+	/**
 	 * Get a user test for an item.
 	 *
 	 * @param   integer  $itemId    The item number


### PR DESCRIPTION
If we send the message `Pull reciever new commits...` we should also reset the tests.

Else we end up in spamming our users on every new commit ;)

### How it should work
- we send the message "This Pull reciever ..."
- than we loop over the testers
- and the bot alter the test result to be `not tested`
- on the next commit the bot don't find any testers (as they are resetted) and don't send the message again.

### I'm not sure with

How we generate the message? `zero-24 - alter_testresult - 2015-10-06 19:53:31 - test: Not tested`
I'm correct in just passing the `json_encode($result)`?

```php
$result = new \stdClass;
$result->user  = $tester;
$result->value = '0';
```