### PR TITLE
Remove the unneded div if we have nothing to show

### DIFF
--- a/templates/tracker/issue.index.twig
+++ b/templates/tracker/issue.index.twig
@@ -294,7 +294,7 @@
             <span class="icon-calendar"></span> {{ item.opened_date|date("j M Y", offset) }}
         </div>
 
-        {% if item.votes or user.id or item.has_code %}
+        {% if item.votes or user.id %}
             {% set mainClass = 'span7' %}
         {% else %}
             {% set mainClass = 'span10' %}
@@ -304,7 +304,7 @@
             {{ item.description|raw }}
         </div>
 
-        {% if item.votes or user.id or item.has_code %}
+        {% if item.votes or user.id %}
         <div class="span3 well">
 
             {% if item.votes or user.id %}


### PR DESCRIPTION
This happens if we have a normal PR without any votes and not logged in.

![unused_div_on_prs](https://cloud.githubusercontent.com/assets/2596554/10331639/29768410-6cd7-11e5-8781-fb19cf59bdb4.JPG)

After this patch the div should not be there ;)