### PR TITLE
 	Add support for project specific issue templates - Fix #748

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Files and folders that should not be pushed to the repo #
 /etc/config.json
 .vagrant/*
+/projects/*
 
 # Apple Files #
 .DS_Store

--- a/cli/Application/Command/Get/Source.php
+++ b/cli/Application/Command/Get/Source.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Part of the Joomla! Tracker application.
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace Application\Command\Get;
+
+use Application\Command\Get\Project;
+
+use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Local as Adapter;
+
+/**
+ * Class for retrieving the source files from GitHub for selected projects.
+ *
+ * @since  1.0
+ */
+class Source extends Project
+{
+	/**
+	 * Constructor.
+	 *
+	 * @since   1.0
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+
+		$this->description = g11n3t('Retrieve project source files from GitHub.');
+	}
+
+	/**
+	 * Execute the command.
+	 *
+	 * @return  $this
+	 *
+	 * @since   1.0
+	 */
+	public function execute()
+	{
+		$this->getApplication()->outputTitle(g11n3t('Retrieve Sources'));
+
+		$this->logOut(g11n3t('Start retrieve sources'))
+			->selectProject()
+			->setupGitHub()
+			->getSources()
+			->out()
+			->logOut(g11n3t('Finished'));
+	}
+
+	/**
+	 * Get source files from GitHub.
+	 *
+	 * @return $this
+	 *
+	 * @since   1.0
+	 */
+	protected function getSources()
+	{
+		$filesystem = new Filesystem(new Adapter($this->project->getSourcePath()));
+
+		// We only "check out" some template files (for now)
+
+		try
+		{
+			// Fetch the contents of the '.github' folder.
+			$files = $this->github->repositories->contents->get(
+				$this->project->getGh_User(),
+				$this->project->getGh_Project(),
+				'.github'
+			);
+
+			if ($files)
+			{
+				foreach ($files as $file)
+				{
+					$fileContents = $this->github->repositories->contents->get(
+						$this->project->getGh_User(),
+						$this->project->getGh_Project(),
+						$file->path
+					);
+
+					$result = $filesystem->put($fileContents->path, base64_decode($fileContents->content));
+
+					if (false == $result)
+					{
+						throw new \RuntimeException('Can not write the file');
+					}
+				}
+			}
+		}
+		catch (\DomainException $exception)
+		{
+			// The '.github' folder does not exist.
+		}
+
+		// Fetch some template files from the root.
+		$files = $this->github->repositories->contents->get(
+			$this->project->getGh_User(),
+			$this->project->getGh_Project(),
+			'/'
+		);
+
+		$knownFiles = ['ISSUE_TEMPLATE'];
+
+		foreach ($files as $file)
+		{
+			if ($file->type != 'file')
+			{
+				continue;
+			}
+
+			foreach ($knownFiles as $knownFile)
+			{
+				if (strpos($file->name, $knownFile) === 0)
+				{
+					$fileContents = $this->github->repositories->contents->get(
+						$this->project->getGh_User(),
+						$this->project->getGh_Project(),
+						$file->path
+					);
+
+					$result = $filesystem->put($fileContents->path, base64_decode($fileContents->content));
+
+					if (false == $result)
+					{
+						throw new \RuntimeException('Can not write the file');
+					}
+				}
+			}
+		}
+
+		return $this;
+	}
+}

--- a/src/App/Projects/TrackerProject.php
+++ b/src/App/Projects/TrackerProject.php
@@ -580,4 +580,68 @@ class TrackerProject implements \Serializable
 
 		return $categories;
 	}
+
+	/**
+	 * Get a location in the file system where the project source files are stored.
+	 *
+	 * @return string
+	 *
+	 * @since    1.0
+	 */
+	public function getSourcePath()
+	{
+		return JPATH_ROOT . '/projects/' . $this->getGh_User() . '/' . $this->getGh_Project() . '/src';
+	}
+
+	/**
+	 * Get a path for a template file.
+	 *
+	 * @param   string  $type  The template type.
+	 *
+	 * @return  string
+	 *
+	 * @since    1.0
+	 */
+	public function getTemplate($type)
+	{
+		switch ($type)
+		{
+			case 'issue':
+				$fileName = 'ISSUE_TEMPLATE';
+				break;
+			case 'pr':
+				$fileName = 'PULL_REQUEST_TEMPLATE';
+				break;
+			case 'contribute':
+				$fileName = 'CONTRIBUTING';
+				break;
+			default:
+			throw new \UnexpectedValueException('Invalid template type');
+		}
+
+		$basePath = $this->getSourcePath();
+
+		foreach (['/.github/', '/'] as $subDir)
+		{
+			// First check: file name with no extension
+			$path = $basePath . $subDir . $fileName;
+
+			if (realpath($path))
+			{
+				return $path;
+			}
+
+			// Second check: file name with '.md' extension
+			$path = $basePath . $subDir . $fileName . '.md';
+
+			if (realpath($path))
+			{
+				return $path;
+			}
+
+			// Third?
+		}
+
+		throw new \DomainException('Template file not found.');
+	}
 }

--- a/src/App/Tracker/Controller/Issue/Add.php
+++ b/src/App/Tracker/Controller/Issue/Add.php
@@ -59,21 +59,33 @@ class Add extends AbstractTrackerController
 
 		$this->getContainer()->get('app')->getUser()->authorize('create');
 
-		// New item
-		$path = JPATH_ROOT . '/src/App/Tracker/tpl/new-issue-template.md';
+		/* @type $project \App\Projects\TrackerProject */
+		$project = $this->getContainer()->get('app')->getProject();
 
-		if (!file_exists($path))
+		try
 		{
-			throw new \RuntimeException('New issue template not found.');
+			// Check if the project has a proper issue template.
+			$path = $project->getTemplate('issue');
+		}
+		catch (\DomainException $exception)
+		{
+			// Use standard template.
+			$path = JPATH_ROOT . '/src/App/Tracker/tpl/new-issue-template.md';
+
+			if (!file_exists($path))
+			{
+				throw new \RuntimeException('New issue template not found.');
+			}
 		}
 
 		// Set some defaults
 		$item = new \stdClass;
+
 		$item->issue_number    = 0;
 		$item->priority        = 3;
 		$item->description_raw = file_get_contents($path);
 
-		$this->view->setProject($this->getContainer()->get('app')->getProject());
+		$this->view->setProject($project);
 		$this->view->setItem($item);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #748 .

#### Summary of Changes

* Fetch issue templates using `jtracker get source`
* Issue templates will be used on opening new issues if they exist, otherwise the standard template is used.

**NOTE** GitHub seems to have some "rules" if a file exists in multiple locations or with multiple extensions. The `.github` folder is searched first, so are files without extension.
This behavior is honored by the PR..

#### Testing Instructions

Code review :wink: 