### PR TITLE
GitHub statuses

### DIFF
--- a/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
@@ -112,10 +112,17 @@ class ReceivePullsHook extends AbstractHookController
 		$data['build']           = $this->data->base->ref;
 		$data['pr_head_sha']     = $this->data->head->sha;
 
-		$commits = (new GitHubHelper($this->github))
-			->getCommits($this->project, $this->data->number);
+		$gitHubHelper = new GitHubHelper(GithubFactory::getInstance($this->getContainer()->get('app')));
+
+		$commits = $gitHubHelper->getCommits($this->project, $this->data->number);
 
 		$data['commits'] = json_encode($commits);
+
+		$combinedStatus = $gitHubHelper->getCombinedStatus($this->project, $this->data->head->sha);
+
+		// Save the merge status to database
+		$data['merge_state'] = $combinedStatus->state;
+		$data['gh_merge_status'] = json_encode($combinedStatus->statuses);
 
 		// Add the closed date if the status is closed
 		if ($this->data->closed_at)
@@ -332,10 +339,16 @@ class ReceivePullsHook extends AbstractHookController
 
 		$data['pr_head_sha'] = $this->data->head->sha;
 
-		$commits = (new GitHubHelper($this->github))
-			->getCommits($this->project, $this->data->number);
+		$gitHubHelper = new GitHubHelper(GithubFactory::getInstance($this->getContainer()->get('app')));
+
+		$commits = $gitHubHelper->getCommits($this->project, $this->data->number);
 
 		$data['commits'] = json_encode($commits);
+
+		$combinedStatus = $gitHubHelper->getCombinedStatus($this->project, $this->data->head->sha);
+
+		$data['merge_state'] = $combinedStatus->state;
+		$data['gh_merge_status'] = json_encode($combinedStatus->statuses);
 
 		try
 		{

--- a/src/JTracker/Github/DataType/Commit/CombinedStatus.php
+++ b/src/JTracker/Github/DataType/Commit/CombinedStatus.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Part of the Joomla Framework GitHub Package
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace JTracker\Github\DataType\Commit;
+
+/**
+ * Class GitHub DataType Commit CombinedStatus.
+ *
+ * @since  1.0
+ */
+class CombinedStatus
+{
+	/**
+	 * @var string
+	 */
+	public $state = '';
+
+	/**
+	 * @var Status[]
+	 */
+	public $statuses = [];
+}

--- a/src/JTracker/Github/Github.php
+++ b/src/JTracker/Github/Github.php
@@ -14,6 +14,7 @@ use \Joomla\Github\Github as JGitHub;
  * Joomla! Tracker class for interacting with a GitHub server instance.
  *
  * @property-read  Package\Issues         $issues         GitHub API object for the issues package.
+ * @property-read  Package\Repositories   $repositories   GitHub API object for the repositories package.
  * @property-read  Package\Markdown       $markdown       GitHub API object for the issues package.
  *
  * @since  1.0

--- a/src/JTracker/Github/Package/Repositories.php
+++ b/src/JTracker/Github/Package/Repositories.php
@@ -1,0 +1,428 @@
+<?php
+/**
+ * Part of the Joomla Framework Github Package
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace JTracker\Github\Package;
+
+use JTracker\Github\Package;
+
+/**
+ * GitHub API Activity class for the Joomla Framework.
+ *
+ * @since  1.0
+ *
+ * @documentation  http://developer.github.com/v3/repos
+ *
+ * @property-read  Repositories\Statuses       $statuses       GitHub API object for statuses.
+ */
+class Repositories extends Package
+{
+	/**
+	 * List your repositories.
+	 *
+	 * List repositories for the authenticated user.
+	 *
+	 * @param   string  $type       Sort type. all, owner, public, private, member. Default: all.
+	 * @param   string  $sort       Sort field. created, updated, pushed, full_name, default: full_name.
+	 * @param   string  $direction  Sort direction. asc or desc, default: when using full_name: asc, otherwise desc.
+	 *
+	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function getListOwn($type = 'all', $sort = 'full_name', $direction = '')
+	{
+		if (false == in_array($type, array('all', 'owner', 'public', 'private', 'member')))
+		{
+			throw new \RuntimeException('Invalid type');
+		}
+
+		if (false == in_array($sort, array('created', 'updated', 'pushed', 'full_name')))
+		{
+			throw new \RuntimeException('Invalid sort field');
+		}
+
+		// Sort direction default: when using full_name: asc, otherwise desc.
+		$direction = ($direction) ? : (('full_name' == $sort) ? 'asc' : 'desc');
+
+		if (false == in_array($direction, array('asc', 'desc')))
+		{
+			throw new \RuntimeException('Invalid sort order');
+		}
+
+		// Build the request path.
+		$path = '/user/repos'
+			. '?type=' . $type
+			. '&sort=' . $sort
+			. '&direction=' . $direction;
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->get($this->fetchUrl($path))
+		);
+	}
+
+	/**
+	 * List user repositories.
+	 *
+	 * List public repositories for the specified user.
+	 *
+	 * @param   string  $user       The user name.
+	 * @param   string  $type       Sort type. all, owner, member. Default: all.
+	 * @param   string  $sort       Sort field. created, updated, pushed, full_name, default: full_name.
+	 * @param   string  $direction  Sort direction. asc or desc, default: when using full_name: asc, otherwise desc.
+	 *
+	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function getListUser($user, $type = 'all', $sort = 'full_name', $direction = '')
+	{
+		if (false == in_array($type, array('all', 'owner', 'member')))
+		{
+			throw new \RuntimeException('Invalid type');
+		}
+
+		if (false == in_array($sort, array('created', 'updated', 'pushed', 'full_name')))
+		{
+			throw new \RuntimeException('Invalid sort field');
+		}
+
+		// Sort direction default: when using full_name: asc, otherwise desc.
+		$direction = ($direction) ? : (('full_name' == $sort) ? 'asc' : 'desc');
+
+		if (false == in_array($direction, array('asc', 'desc')))
+		{
+			throw new \RuntimeException('Invalid sort order');
+		}
+
+		// Build the request path.
+		$path = '/users/' . $user . '/repos'
+			. '?type=' . $type
+			. '&sort=' . $sort
+			. '&direction=' . $direction;
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->get($this->fetchUrl($path))
+		);
+	}
+
+	/**
+	 * List organization repositories.
+	 *
+	 * List repositories for the specified org.
+	 *
+	 * @param   string  $org   The name of the organization.
+	 * @param   string  $type  Sort type. all, public, private, forks, sources, member. Default: all.
+	 *
+	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function getListOrg($org, $type = 'all')
+	{
+		if (false == in_array($type, array('all', 'public', 'private', 'forks', 'sources', 'member')))
+		{
+			throw new \RuntimeException('Invalid type');
+		}
+
+		// Build the request path.
+		$path = '/orgs/' . $org . '/repos'
+			. '?type=' . $type;
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->get($this->fetchUrl($path))
+		);
+	}
+
+	/**
+	 * List all repositories.
+	 *
+	 * This provides a dump of every repository, in the order that they were created.
+	 *
+	 * @param   integer  $id  The integer ID of the last Repository that you’ve seen.
+	 *
+	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function getList($id = 0)
+	{
+		// Build the request path.
+		$path = '/repositories';
+		$path .= ($id) ? '?since=' . (int) $id : '';
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->get($this->fetchUrl($path))
+		);
+	}
+
+	/**
+	 * Create.
+	 *
+	 * Create a new repository for the authenticated user or an organization. OAuth users must supply repo scope.
+	 *
+	 * @param   string   $name                The repository name.
+	 * @param   string   $org                 The organization name (if needed).
+	 * @param   string   $description         The repository description.
+	 * @param   string   $homepage            The repository homepage.
+	 * @param   boolean  $private             Set true to create a private repository, false to create a public one.
+	 *                                        Creating private repositories requires a paid GitHub account.
+	 * @param   boolean  $has_issues          Set true to enable issues for this repository, false to disable them.
+	 * @param   boolean  $has_wiki            Set true to enable the wiki for this repository, false to disable it.
+	 * @param   boolean  $has_downloads       Set true to enable downloads for this repository, false to disable them.
+	 * @param   integer  $team_id             The id of the team that will be granted access to this repository.
+	 *                                        This is only valid when creating a repo in an organization.
+	 * @param   boolean  $auto_init           true to create an initial commit with empty README.
+	 * @param   string   $gitignore_template  Desired language or platform .gitignore template to apply.
+	 *                                        Use the name of the template without the extension.
+	 *                                        For example, “Haskell” Ignored if auto_init parameter is not provided.
+	 *
+	 * @return  object
+	 *
+	 * @since   1.0
+	 */
+	public function create($name, $org = '', $description = '', $homepage = '', $private = false, $has_issues = false,
+		$has_wiki = false, $has_downloads = false, $team_id = 0, $auto_init = false, $gitignore_template = '')
+	{
+		$path = ($org)
+			// Create a repository for an organization
+			? '/orgs/' . $org . '/repos'
+			// Create a repository for a user
+			: '/user/repos';
+
+		$data = array(
+			'name'               => $name,
+			'description'        => $description,
+			'homepage'           => $homepage,
+			'private'            => $private,
+			'has_issues'         => $has_issues,
+			'has_wiki'           => $has_wiki,
+			'has_downloads'      => $has_downloads,
+			'team_id'            => $team_id,
+			'auto_init'          => $auto_init,
+			'gitignore_template' => $gitignore_template
+		);
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->post($this->fetchUrl($path), json_encode($data)),
+			201
+		);
+	}
+
+	/**
+	 * Get a repository.
+	 *
+	 * @param   string  $owner  Repository owner.
+	 * @param   string  $repo   Repository name.
+	 *
+	 * @return  object
+	 *
+	 * @since   1.0
+	 */
+	public function get($owner, $repo)
+	{
+		// Build the request path.
+		$path = '/repos/' . $owner . '/' . $repo;
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->get($this->fetchUrl($path))
+		);
+	}
+
+	/**
+	 * Edit a repository.
+	 *
+	 * @param   string   $owner           Repository owner.
+	 * @param   string   $repo            Repository name.
+	 * @param   string   $name            The repository name.
+	 * @param   string   $description     The repository description.
+	 * @param   string   $homepage        The repository homepage.
+	 * @param   boolean  $private         Set true to create a private repository, false to create a public one.
+	 *                                    Creating private repositories requires a paid GitHub account.
+	 * @param   boolean  $has_issues      Set true to enable issues for this repository, false to disable them.
+	 * @param   boolean  $has_wiki        Set true to enable the wiki for this repository, false to disable it.
+	 * @param   boolean  $has_downloads   Set true to enable downloads for this repository, false to disable them.
+	 * @param   string   $default_branch  Update the default branch for this repository
+	 *
+	 * @return  object
+	 *
+	 * @since   1.0
+	 */
+	public function edit($owner, $repo, $name, $description = '', $homepage = '', $private = false, $has_issues = false,
+		$has_wiki = false, $has_downloads = false, $default_branch = '')
+	{
+		$path = '/repos/' . $owner . '/' . $repo;
+
+		$data = array(
+			'name'           => $name,
+			'description'    => $description,
+			'homepage'       => $homepage,
+			'private'        => $private,
+			'has_issues'     => $has_issues,
+			'has_wiki'       => $has_wiki,
+			'has_downloads'  => $has_downloads,
+			'default_branch' => $default_branch
+		);
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->patch($this->fetchUrl($path), json_encode($data))
+		);
+	}
+
+	/**
+	 * List contributors.
+	 *
+	 * @param   string   $owner  Repository owner.
+	 * @param   string   $repo   Repository name.
+	 * @param   boolean  $anon   Set to 1 or true to include anonymous contributors in results.
+	 *
+	 * @return object
+	 */
+	public function getListContributors($owner, $repo, $anon = false)
+	{
+		// Build the request path.
+		$path = '/repos/' . $owner . '/' . $repo . '/contributors';
+
+		$path .= ($anon) ? '?anon=true' : '';
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->get($this->fetchUrl($path))
+		);
+	}
+
+	/**
+	 * List languages.
+	 *
+	 * List languages for the specified repository. The value on the right of a language is the number of bytes of code
+	 * written in that language.
+	 *
+	 * @param   string  $owner  Repository owner.
+	 * @param   string  $repo   Repository name.
+	 *
+	 * @return object
+	 */
+	public function getListLanguages($owner, $repo)
+	{
+		// Build the request path.
+		$path = '/repos/' . $owner . '/' . $repo . '/languages';
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->get($this->fetchUrl($path))
+		);
+	}
+
+	/**
+	 * List Teams
+	 *
+	 * @param   string  $owner  Repository owner.
+	 * @param   string  $repo   Repository name.
+	 *
+	 * @return object
+	 */
+	public function getListTeams($owner, $repo)
+	{
+		// Build the request path.
+		$path = '/repos/' . $owner . '/' . $repo . '/teams';
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->get($this->fetchUrl($path))
+		);
+	}
+
+	/**
+	 * List Tags.
+	 *
+	 * @param   string  $owner  Repository owner.
+	 * @param   string  $repo   Repository name.
+	 *
+	 * @return object
+	 */
+	public function getListTags($owner, $repo)
+	{
+		// Build the request path.
+		$path = '/repos/' . $owner . '/' . $repo . '/tags';
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->get($this->fetchUrl($path))
+		);
+	}
+
+	/**
+	 * List Branches.
+	 *
+	 * @param   string  $owner  Repository owner.
+	 * @param   string  $repo   Repository name.
+	 *
+	 * @return object
+	 */
+	public function getListBranches($owner, $repo)
+	{
+		// Build the request path.
+		$path = '/repos/' . $owner . '/' . $repo . '/branches';
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->get($this->fetchUrl($path))
+		);
+	}
+
+	/**
+	 * Get a Branch.
+	 *
+	 * @param   string  $owner   Repository owner.
+	 * @param   string  $repo    Repository name.
+	 * @param   string  $branch  Branch name.
+	 *
+	 * @return object
+	 */
+	public function getBranch($owner, $repo, $branch)
+	{
+		// Build the request path.
+		$path = '/repos/' . $owner . '/' . $repo . '/branches/' . $branch;
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->get($this->fetchUrl($path))
+		);
+	}
+
+	/**
+	 * Delete a Repository.
+	 *
+	 * Deleting a repository requires admin access. If OAuth is used, the delete_repo scope is required.
+	 *
+	 * @param   string  $owner  Repository owner.
+	 * @param   string  $repo   Repository name.
+	 *
+	 * @return object
+	 */
+	public function delete($owner, $repo)
+	{
+		// Build the request path.
+		$path = '/repos/' . $owner . '/' . $repo;
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->delete($this->fetchUrl($path))
+		);
+	}
+}

--- a/src/JTracker/Github/Package/Repositories/Statuses.php
+++ b/src/JTracker/Github/Package/Repositories/Statuses.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Part of the Joomla Framework Github Package
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace JTracker\Github\Package\Repositories;
+
+use JTracker\Github\DataType\Commit\CombinedStatus;
+use JTracker\Github\Package;
+
+/**
+ * GitHub API References class for the Joomla Framework.
+ *
+ * @documentation http://developer.github.com/v3/repos/statuses
+ *
+ * @since  1.0
+ */
+class Statuses extends Package
+{
+	/**
+	 * Method to create a status.
+	 *
+	 * @param   string  $user         The name of the owner of the GitHub repository.
+	 * @param   string  $repo         The name of the GitHub repository.
+	 * @param   string  $sha          The SHA1 value for which to set the status.
+	 * @param   string  $state        The state (pending, success, error or failure).
+	 * @param   string  $targetUrl    Optional target URL.
+	 * @param   string  $description  Optional description for the status.
+	 * @param   string  $context      A string label to differentiate this status from the status of other systems.
+	 * 							      Default: "default"
+	 *
+	 * @throws \InvalidArgumentException
+	 * @throws \DomainException
+	 *
+	 * @return object
+	 *
+	 * @since   1.0
+	 *
+	 */
+	public function create($user, $repo, $sha, $state, $targetUrl = null, $description = null, $context = null)
+	{
+		// Build the request path.
+		$path = '/repos/' . $user . '/' . $repo . '/statuses/' . $sha;
+
+		if (!in_array($state, array('pending', 'success', 'error', 'failure')))
+		{
+			throw new \InvalidArgumentException('State must be one of pending, success, error or failure.');
+		}
+
+		// Build the request data.
+		$data = array(
+			'state' => $state
+		);
+
+		if (!is_null($targetUrl))
+		{
+			$data['target_url'] = $targetUrl;
+		}
+
+		if (!is_null($description))
+		{
+			$data['description'] = $description;
+		}
+
+		if (!is_null($context))
+		{
+			$data['context'] = $context;
+		}
+
+		// Send the request.
+		return $this->processResponse(
+			$this->client->post($this->fetchUrl($path), json_encode($data)),
+			201
+		);
+	}
+
+	/**
+	 * Method to list statuses for an SHA.
+	 *
+	 * @param   string  $user  The name of the owner of the GitHub repository.
+	 * @param   string  $repo  The name of the GitHub repository.
+	 * @param   string  $sha   SHA1 for which to get the statuses.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function getList($user, $repo, $sha)
+	{
+		// Build the request path.
+		$path = '/repos/' . $user . '/' . $repo . '/statuses/' . $sha;
+
+		// Send the request.
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
+	}
+
+	/**
+	 * Method to access a combined view of commit statuses for a given ref.
+	 *
+	 * @param   string  $user  The name of the owner of the GitHub repository.
+	 * @param   string  $repo  The name of the GitHub repository.
+	 * @param   string  $ref   Ref to fetch the status for. It can be a SHA, a branch name, or a tag name.
+	 *
+	 * @return  CombinedStatus
+	 *
+	 * @since   1.0
+	 */
+	public function getCombined($user, $repo, $ref)
+	{
+		// Build the request path.
+		$path = '/repos/' . $user . '/' . $repo . '/commits/' . $ref . '/status';
+
+		// Send the request.
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
+	}
+}

--- a/src/JTracker/Helper/GitHubHelper.php
+++ b/src/JTracker/Helper/GitHubHelper.php
@@ -16,6 +16,7 @@ use Joomla\Date\Date;
 
 use JTracker\Application;
 use JTracker\Github\DataType\Commit;
+use JTracker\Github\DataType\Commit\CombinedStatus;
 use JTracker\Github\DataType\Commit\Status;
 use JTracker\Github\DataType\JTracker\Issues\Comment;
 use JTracker\GitHub\Github;
@@ -141,6 +142,41 @@ class GitHubHelper
 		}
 
 		return $commits;
+	}
+
+	/**
+	 * Get the combined GitHub merge status for an issue.
+	 *
+	 * @param   TrackerProject  $project  The project object.
+	 * @param   string          $ref      Ref to fetch the status for. It can be a SHA, a branch name, or a tag name.
+	 *
+	 * @return  CombinedStatus
+	 *
+	 * @since    1.0
+	 */
+	public function getCombinedStatus(TrackerProject $project, $ref)
+	{
+		$combinedStatus = new CombinedStatus;
+
+		$combined = $this->gitHub->repositories->statuses->getCombined(
+			$project->gh_user, $project->gh_project, $ref
+		);
+
+		$combinedStatus->state = $combined->state;
+
+		foreach ($combined->statuses as $status)
+		{
+			$s = new Status;
+
+			$s->state = $status->state;
+			$s->targetUrl = $status->target_url;
+			$s->description = $status->description;
+			$s->context = $status->context;
+
+			$combinedStatus->statuses[] = $s;
+		}
+
+		return $combinedStatus;
 	}
 
 	/**

--- a/templates/tracker/issue.index.twig
+++ b/templates/tracker/issue.index.twig
@@ -190,6 +190,7 @@
                 {% for status in item.gh_merge_status %}
                     <li>
                         {{ status.state|mergeBadge|raw }}
+                        <strong>{{ status.context }}</strong>
                         {{ status.description }}
                         <a href="{{ status.targetUrl }}" title="{{ status.context }}">
                             {{ 'Details'|_ }}
@@ -198,7 +199,7 @@
                 {% endfor %}
             {% else %}
                 <li>
-                    {{ status.state|mergeBadge|raw }}
+                    {{ item.merge_state|mergeBadge|raw }}
                     {% if item.gh_merge_status.description %}
                         {{ item.gh_merge_status.description }}
                     {% endif %}

--- a/templates/tracker/issue.index.twig
+++ b/templates/tracker/issue.index.twig
@@ -182,24 +182,35 @@
         {% endif %}
     </ul>
 
-        {% if item.merge_state %}
-            <ul class="breadcrumb">
-                <li>{{ item.merge_state|mergeBadge|raw }}</li>
-
-                {% if item.gh_merge_status.targetUrl %}
+<!-- Merge Status -->
+    {% if item.merge_state %}
+        <h4>{{ item.merge_state|mergeBadge|raw }}</h4>
+        <ul class="unstyled">
+            {% if item.gh_merge_status is iterable %}
+                {% for status in item.gh_merge_status %}
                     <li>
-                        {% if item.gh_merge_status.description %}
-                            {{ item.gh_merge_status.description }}
-                        {% endif %}
-                    </li>
-                    <li>
-                        <a href="{{ item.gh_merge_status.targetUrl }}">
+                        {{ status.state|mergeBadge|raw }}
+                        {{ status.description }}
+                        <a href="{{ status.targetUrl }}" title="{{ status.context }}">
                             {{ 'Details'|_ }}
                         </a>
                     </li>
-                {% endif %}
-            </ul>
-        {% endif %}
+                {% endfor %}
+            {% else %}
+                <li>
+                    {{ status.state|mergeBadge|raw }}
+                    {% if item.gh_merge_status.description %}
+                        {{ item.gh_merge_status.description }}
+                    {% endif %}
+                    {% if item.gh_merge_status.targetUrl %}
+                        <a href="{{ item.gh_merge_status.targetUrl }}">
+                            {{ 'Details'|_ }}
+                        </a>
+                    {% endif %}
+                </li>
+            {% endif %}
+        </ul>
+    {% endif %}
 
 <!-- Categories -->
     {% if item.categories %}


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes
Some time ago GitHub introduced the [Combined Status API](https://developer.github.com/changes/2014-03-27-combined-status-api/)([API](https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref))
Currently we display only the last status in the item view (and its state in the list view)

* Importing statuses has been added (and tested) on CLI import.
* Importing statuses has been added (and **NOT** tested) on Hooks import.

#### Testing Instructions
Merge, push, wait until PRs are updated or run the `get project` command with the `-f` option on the server.