### PR TITLE
Catch when pull requests are merged and set state accordingly

### DIFF
--- a/src/App/Tracker/Controller/AbstractHookController.php
+++ b/src/App/Tracker/Controller/AbstractHookController.php
@@ -420,7 +420,7 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 				$status = 10;
 
 				// If the action is closed and this is a pull request, check if the request was merged and set the status to "Fixed in Code Base"
-				if ($this->type == 'pulls' && $this->hookData->pull_request->base->merged)
+				if ($this->type == 'pulls' && $this->hookData->pull_request->merged)
 				{
 					$status = 5;
 				}

--- a/src/App/Tracker/Controller/AbstractHookController.php
+++ b/src/App/Tracker/Controller/AbstractHookController.php
@@ -419,6 +419,12 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 			case 'closed':
 				$status = 10;
 
+				// If the action is closed and this is a pull request, check if the request was merged and set the status to "Fixed in Code Base"
+				if ($this->type == 'pulls' && $this->hookData->pull_request->base->merged)
+				{
+					$status = 5;
+				}
+
 				// Get the list of status IDs based on the GitHub close state
 				$statusIds = (new StatusTable($this->db))
 					->getStateStatusIds(true);

--- a/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
@@ -204,12 +204,12 @@ class ReceivePullsHook extends AbstractHookController
 		}
 
 		// Add a merge record to the activity table if the request was merged
-		if ($action == 'closed' && $this->data->base->merged)
+		if ($action == 'closed' && $this->data->merged)
 		{
 			$this->addActivityEvent(
 				'merge',
 				$data['closed_date'],
-				$this->data->base->merged_by->login,
+				$this->data->merged_by->login,
 				$this->project->project_id,
 				$this->data->number
 			);
@@ -425,12 +425,12 @@ class ReceivePullsHook extends AbstractHookController
 		}
 
 		// Add a merge record to the activity table if the request was merged
-		if ($action == 'closed' && $this->data->base->merged)
+		if ($action == 'closed' && $this->data->merged)
 		{
 			$this->addActivityEvent(
 				'merge',
 				$this->data->closed_at,
-				$this->data->base->merged_by->login,
+				$this->data->merged_by->login,
 				$this->project->project_id,
 				$this->data->number
 			);

--- a/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
@@ -203,6 +203,18 @@ class ReceivePullsHook extends AbstractHookController
 			);
 		}
 
+		// Add a merge record to the activity table if the request was merged
+		if ($action == 'closed' && $this->data->base->merged)
+		{
+			$this->addActivityEvent(
+				'merge',
+				$data['closed_date'],
+				$this->data->base->merged_by->login,
+				$this->project->project_id,
+				$this->data->number
+			);
+		}
+
 		// Store was successful, update status
 		$this->logger->info(
 			sprintf(
@@ -407,6 +419,18 @@ class ReceivePullsHook extends AbstractHookController
 				'close',
 				$this->data->closed_at,
 				$this->hookData->sender->login,
+				$this->project->project_id,
+				$this->data->number
+			);
+		}
+
+		// Add a merge record to the activity table if the request was merged
+		if ($action == 'closed' && $this->data->base->merged)
+		{
+			$this->addActivityEvent(
+				'merge',
+				$this->data->closed_at,
+				$this->data->base->merged_by->login,
 				$this->project->project_id,
 				$this->data->number
 			);


### PR DESCRIPTION
#### Summary of Changes

Pull request webhooks are setting some merge state data which we can use to track statuses better in the application.  This PR will check if a pull request gets closed and is merged (looks like it applies to the big green button only, I need to find something merged manually) and if so we'll set the closed status to "Fixed in Code Base" instead of the generic "Closed".  We'll also add a merge activity for the person who merged the item (though it looks like this happens already but I can't trace down what's adding it).

#### Testing Instructions

Review changes and compare them against the pull request webhook data (https://github.com/joomla/jissues/settings/hooks/1060432 has a log of them for repo admins).  Throw this patch on a server that can receive hooks, close a PR on a project the app supports, and validate the state and activity data is updated accordingly.