### PR TITLE
Log Exceptions per PSR-3 standard

### DIFF
--- a/src/App/Debug/TrackerDebugger.php
+++ b/src/App/Debug/TrackerDebugger.php
@@ -525,9 +525,15 @@ class TrackerDebugger implements LoggerAwareInterface
 	 *
 	 * @since   1.0
 	 */
-	public function renderException(\Exception $exception, array $context = array())
+	public function renderException(\Exception $exception, array $context = [])
 	{
 		static $loaded = false;
+
+		// Attach the Exception to the context array (per PSR-3) if not already
+		if (!isset($context['exception']))
+		{
+			$context['exception'] = $exception;
+		}
 
 		if ($loaded)
 		{

--- a/src/App/Tracker/Controller/AbstractHookController.php
+++ b/src/App/Tracker/Controller/AbstractHookController.php
@@ -99,7 +99,7 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 		}
 		catch (\RuntimeException $e)
 		{
-			$this->logger->error('Error checking the database for the GitHub ID:' . $e->getMessage());
+			$this->logger->error('Error checking the database for the GitHub ID', ['exception' => $e]);
 			$this->getContainer()->get('app')->close();
 		}
 	}
@@ -130,10 +130,10 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 		{
 			$this->logger->info(
 				sprintf(
-					'Error retrieving the project alias for GitHub repo %s in the database: %s',
-					$this->hookData->repository->name,
-					$e->getMessage()
-				)
+					'Error retrieving the project alias for GitHub repo %s in the database',
+					$this->hookData->repository->name
+				),
+				['exception' => $e]
 			);
 
 			$this->getContainer()->get('app')->close();
@@ -273,11 +273,12 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 		{
 			$this->logger->info(
 				sprintf(
-					'Error storing %s activity to the database (ProjectId: %d, ItemNo: %d): %s',
+					'Error storing %s activity to the database (ProjectId: %d, ItemNo: %d)',
 					$event,
-					$projectId, $itemNumber,
-					$exception->getMessage()
-				)
+					$projectId,
+					$itemNumber
+				),
+				['exception' => $exception]
 			);
 
 			$this->getContainer()->get('app')->close();
@@ -309,10 +310,10 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 		{
 			$this->logger->info(
 				sprintf(
-					'Error parsing comment %d with GH Markdown: %s',
-					$this->hookData->comment->id,
-					$exception->getMessage()
-				)
+					'Error parsing comment %d with GH Markdown',
+					$this->hookData->comment->id
+				),
+				['exception' => $exception]
 			);
 
 			return '';
@@ -338,12 +339,12 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 		{
 			$this->logger->error(
 				sprintf(
-					'Error parsing the labels for GitHub issue %s/%s #%d - %s',
+					'Error parsing the labels for GitHub issue %s/%s #%d',
 					$this->project->gh_user,
 					$this->project->gh_project,
-					$issueId,
-					$exception->getMessage()
-				)
+					$issueId
+				),
+				['exception' => $exception]
 			);
 
 			return '';
@@ -385,12 +386,12 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 				{
 					$this->logger->error(
 						sprintf(
-							'Error adding label %s for project %s/%s to the database: %s',
+							'Error adding label %s for project %s/%s to the database',
 							$label->name,
 							$this->project->gh_user,
-							$this->project->gh_project,
-							$exception->getMessage()
-						)
+							$this->project->gh_project
+						),
+						['exception' => $exception]
 					);
 				}
 			}

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -44,15 +44,11 @@ abstract class AbstractListener
 
 		if ($issueNumber === null)
 		{
-			$logger->error(
-				sprintf(
-					'Error retrieving issue number for %s/%s',
-					$project->gh_user,
-					$project->gh_project
-				)
-			);
+			$message = sprintf('Error retrieving issue number for %s/%s', $project->gh_user, $project->gh_project);
 
-			throw new \RuntimeException('Error retrieving issue number for ' . $project->gh_user . '/' . $project->gh_project);
+			$logger->error($message);
+
+			throw new \RuntimeException($message);
 		}
 
 		// Get the labels for the pull's issue
@@ -64,15 +60,15 @@ abstract class AbstractListener
 		{
 			$logger->error(
 				sprintf(
-					'Error retrieving labels for GitHub item %s/%s #%d - %s',
+					'Error retrieving labels for GitHub item %s/%s #%d',
 					$project->gh_user,
 					$project->gh_project,
-					$issueNumber,
-					$e->getMessage()
-				)
+					$issueNumber
+				),
+				['exception' => $e]
 			);
 
-			throw new \RuntimeException($e->getMessage(), 0, $e);
+			throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
 		}
 
 		// Check if the label present that return true
@@ -112,15 +108,11 @@ abstract class AbstractListener
 
 		if ($issueNumber === null)
 		{
-			$logger->error(
-				sprintf(
-					'Error retrieving issue number for %s/%s',
-					$project->gh_user,
-					$project->gh_project
-				)
-			);
+			$message = sprintf('Error retrieving issue number for %s/%s', $project->gh_user, $project->gh_project);
 
-			throw new \RuntimeException('Error retrieving issue number for ' . $project->gh_user . '/' . $project->gh_project);
+			$logger->error($message);
+
+			throw new \RuntimeException($message);
 		}
 
 		// Only try to remove labels if the array isn't empty
@@ -150,16 +142,16 @@ abstract class AbstractListener
 				{
 					$logger->error(
 						sprintf(
-							'Error removing the %s label from GitHub pull request %s/%s #%d - %s',
+							'Error removing the %s label from GitHub pull request %s/%s #%d',
 							$removeLabel,
 							$project->gh_user,
 							$project->gh_project,
-							$issueNumber,
-							$e->getMessage()
-						)
+							$issueNumber
+						),
+						['exception' => $e]
 					);
 
-					throw new \RuntimeException($e->getMessage(), 0, $e);
+					throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
 				}
 			}
 		}
@@ -247,15 +239,15 @@ abstract class AbstractListener
 			{
 				$logger->error(
 					sprintf(
-						'Error adding labels to GitHub pull request %s/%s #%d - %s',
+						'Error adding labels to GitHub pull request %s/%s #%d',
 						$project->gh_user,
 						$project->gh_project,
-						$issueNumber,
-						$e->getMessage()
-					)
+						$issueNumber
+					),
+					['exception' => $e]
 				);
 
-				throw new \RuntimeException($e->getMessage(), 0, $e);
+				throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
 			}
 		}
 	}

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -177,12 +177,12 @@ class JoomlacmsPullsListener extends AbstractListener
 				{
 					$logger->error(
 						sprintf(
-							'Error updating the state for issue %s/%s #%d on the tracker: %s',
+							'Error updating the state for issue %s/%s #%d on the tracker',
 							$project->gh_user,
 							$project->gh_project,
-							$hookData->pull_request->number,
-							$e->getMessage()
-						)
+							$hookData->pull_request->number
+						),
+						['exception' => $e]
 					);
 				}
 
@@ -200,12 +200,12 @@ class JoomlacmsPullsListener extends AbstractListener
 			{
 				$logger->error(
 					sprintf(
-						'Error posting comment to GitHub pull request %s/%s #%d - %s',
+						'Error posting comment to GitHub pull request %s/%s #%d',
 						$project->gh_user,
 						$project->gh_project,
-						$hookData->pull_request->number,
-						$e->getMessage()
-					)
+						$hookData->pull_request->number
+					),
+					['exception' => $e]
 				);
 			}
 		}
@@ -257,12 +257,12 @@ class JoomlacmsPullsListener extends AbstractListener
 			{
 				$logger->error(
 					sprintf(
-						'Error posting comment to GitHub pull request %s/%s #%d - %s',
+						'Error posting comment to GitHub pull request %s/%s #%d',
 						$project->gh_user,
 						$project->gh_project,
-						$hookData->pull_request->number,
-						$e->getMessage()
-					)
+						$hookData->pull_request->number
+					),
+					['exception' => $e]
 				);
 			}
 		}
@@ -306,15 +306,15 @@ class JoomlacmsPullsListener extends AbstractListener
 		{
 			$logger->error(
 				sprintf(
-					'Error retrieving modified files for GitHub item %s/%s #%d - %s',
+					'Error retrieving modified files for GitHub item %s/%s #%d',
 					$project->gh_user,
 					$project->gh_project,
-					$hookData->pull_request->number,
-					$e->getMessage()
-				)
+					$hookData->pull_request->number
+				),
+				['exception' => $e]
 			);
 
-			$files = array();
+			$files = [];
 		}
 
 		$composerChange   = $this->checkComposerChange($files);
@@ -484,12 +484,12 @@ class JoomlacmsPullsListener extends AbstractListener
 		{
 			$logger->error(
 				sprintf(
-					'Error setting the status to pending in local application for GitHub pull request %s/%s #%d - %s',
+					'Error setting the status to pending in local application for GitHub pull request %s/%s #%d',
 					$project->gh_user,
 					$project->gh_project,
-					$table->issue_number,
-					$e->getMessage()
-				)
+					$table->issue_number
+				),
+				['exception' => $e]
 			);
 		}
 	}
@@ -544,12 +544,12 @@ class JoomlacmsPullsListener extends AbstractListener
 		{
 			$logger->error(
 				sprintf(
-					'Error updating the title for GitHub pull request %s/%s #%d - %s',
+					'Error updating the title for GitHub pull request %s/%s #%d',
 					$project->gh_user,
 					$project->gh_project,
-					$hookData->pull_request->number,
-					$e->getMessage()
-				)
+					$hookData->pull_request->number
+				),
+				['exception' => $e]
 			);
 
 			// Don't change the title locally
@@ -566,12 +566,12 @@ class JoomlacmsPullsListener extends AbstractListener
 		{
 			$logger->error(
 				sprintf(
-					'Error updating the title for issue %s/%s #%d on the tracker: %s',
+					'Error updating the title for issue %s/%s #%d on the tracker',
 					$project->gh_user,
 					$project->gh_project,
-					$hookData->issue->number,
-					$e->getMessage()
-				)
+					$hookData->issue->number
+				),
+				['exception' => $e]
 			);
 		}
 	}
@@ -633,12 +633,12 @@ class JoomlacmsPullsListener extends AbstractListener
 			{
 				$logger->error(
 					sprintf(
-						'Error posting comment to GitHub pull request %s/%s #%d - %s',
+						'Error posting comment to GitHub pull request %s/%s #%d',
 						$project->gh_user,
 						$project->gh_project,
-						$hookData->pull_request->number,
-						$e->getMessage()
-					)
+						$hookData->pull_request->number
+					),
+					['exception' => $e]
 				);
 			}
 		}

--- a/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
@@ -54,7 +54,7 @@ class ReceiveCommentsHook extends AbstractHookController
 		}
 		catch (\RuntimeException $e)
 		{
-			$this->logger->error('Error checking the database for comment ID:' . $e->getMessage());
+			$this->logger->error('Error checking the database for comment ID', ['exception' => $e]);
 			$this->getContainer()->get('app')->close();
 		}
 
@@ -143,11 +143,7 @@ class ReceiveCommentsHook extends AbstractHookController
 		}
 		catch (\Exception $e)
 		{
-			$this->logger->error(
-				'Error loading the database for comment '
-				. $this->hookData->issue->number
-				. ':' . $e->getMessage()
-			);
+			$this->logger->error('Error loading the database for comment ' . $this->hookData->issue->number, ['exception' => $e]);
 		}
 
 		// Store was successful, update status
@@ -225,12 +221,12 @@ class ReceiveCommentsHook extends AbstractHookController
 		{
 			$this->logger->error(
 				sprintf(
-					'Error adding GitHub issue %s/%s #%d to the tracker: %s',
+					'Error adding GitHub issue %s/%s #%d to the tracker',
 					$this->project->gh_user,
 					$this->project->gh_project,
-					$this->hookData->issue->number,
-					$e->getMessage()
-				)
+					$this->hookData->issue->number
+				),
+				['exception' => $e]
 			);
 
 			$this->getContainer()->get('app')->close();
@@ -297,9 +293,7 @@ class ReceiveCommentsHook extends AbstractHookController
 		}
 		catch (\Exception $e)
 		{
-			$this->logger->error(
-				'Error updating the database for comment ' . $id . ':' . $e->getMessage()
-			);
+			$this->logger->error('Error updating the database for comment ' . $id, ['exception' => $e]);
 
 			$this->getContainer()->get('app')->close();
 		}
@@ -318,11 +312,7 @@ class ReceiveCommentsHook extends AbstractHookController
 		}
 		catch (\Exception $e)
 		{
-			$this->logger->error(
-				'Error loading the database for comment '
-				. $this->hookData->issue->number
-				. ':' . $e->getMessage()
-			);
+			$this->logger->error('Error loading the database for comment ' . $this->hookData->issue->number, ['exception' => $e]);
 		}
 
 		// Store was successful, update status

--- a/src/App/Tracker/Controller/Hooks/ReceiveIssuesHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveIssuesHook.php
@@ -117,12 +117,12 @@ class ReceiveIssuesHook extends AbstractHookController
 		{
 			$this->logger->error(
 				sprintf(
-					'Error adding GitHub issue %s/%s #%d to the tracker: %s',
+					'Error adding GitHub issue %s/%s #%d to the tracker',
 					$this->project->gh_user,
 					$this->project->gh_project,
-					$this->hookData->issue->number,
-					$e->getMessage()
-				)
+					$this->hookData->issue->number
+				),
+				['exception' => $e]
 			);
 
 			$this->getContainer()->get('app')->close();
@@ -199,12 +199,12 @@ class ReceiveIssuesHook extends AbstractHookController
 		{
 			$this->logger->error(
 				sprintf(
-					'Error loading GitHub issue %s/%s #%d in the tracker: %s',
+					'Error loading GitHub issue %s/%s #%d in the tracker',
 					$this->project->gh_user,
 					$this->project->gh_project,
-					$this->hookData->issue->number,
-					$e->getMessage()
-				)
+					$this->hookData->issue->number
+				),
+				['exception' => $e]
 			);
 
 			$this->getContainer()->get('app')->close();
@@ -272,13 +272,13 @@ class ReceiveIssuesHook extends AbstractHookController
 		{
 			$this->logger->error(
 				sprintf(
-					'Error updating GitHub issue %s/%s #%d (Database ID #%d) in the tracker: %s',
+					'Error updating GitHub issue %s/%s #%d (Database ID #%d) in the tracker',
 					$this->project->gh_user,
 					$this->project->gh_project,
 					$this->hookData->issue->number,
-					$table->id,
-					$e->getMessage()
-				)
+					$table->id
+				),
+				['exception' => $e]
 			);
 
 			$this->getContainer()->get('app')->close();

--- a/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
@@ -157,15 +157,14 @@ class ReceivePullsHook extends AbstractHookController
 		{
 			$this->setStatusCode($e->getCode());
 			$logMessage = sprintf(
-				'Error adding GitHub pull request %s/%s #%d to the tracker: %s',
+				'Error adding GitHub pull request %s/%s #%d to the tracker',
 				$this->project->gh_user,
 				$this->project->gh_project,
-				$this->data->number,
-				$e->getMessage()
+				$this->data->number
 			);
-			$this->response->error = $logMessage;
+			$this->response->error = $logMessage . ': ' . $e->getMessage();
 
-			$this->logger->error($logMessage);
+			$this->logger->error($logMessage, ['exception' => $e]);
 
 			return false;
 		}
@@ -241,14 +240,13 @@ class ReceivePullsHook extends AbstractHookController
 		{
 			$this->setStatusCode($e->getCode());
 			$logMessage = sprintf(
-				'Error loading GitHub issue %s/%s #%d in the tracker: %s',
+				'Error loading GitHub issue %s/%s #%d in the tracker',
 				$this->project->gh_user,
 				$this->project->gh_project,
-				$this->data->number,
-				$e->getMessage()
+				$this->data->number
 			);
-			$this->response->error = $logMessage;
-			$this->logger->error($logMessage);
+			$this->response->error = $logMessage . ': ' . $e->getMessage();
+			$this->logger->error($logMessage, ['exception' => $e]);
 
 			return false;
 		}
@@ -358,15 +356,14 @@ class ReceivePullsHook extends AbstractHookController
 		{
 			$this->setStatusCode($e->getCode());
 			$logMessage = sprintf(
-				'Error updating GitHub pull request %s/%s #%d (Database ID #%d) to the tracker: %s',
+				'Error updating GitHub pull request %s/%s #%d (Database ID #%d) to the tracker',
 				$this->project->gh_user,
 				$this->project->gh_project,
 				$this->data->number,
-				$table->id,
-				$e->getMessage()
+				$table->id
 			);
-			$this->response->error = $logMessage;
-			$this->logger->error($logMessage);
+			$this->response->error = $logMessage . ': ' . $e->getMessage();
+			$this->logger->error($logMessage, ['exception' => $e]);
 
 			return false;
 		}

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -159,19 +159,18 @@ class Save extends AbstractTrackerController
 				$this->getContainer()->get('app')->getLogger()->error(
 					sprintf(
 						'Error code %1$s received from GitHub when editing an issue with the following data:'
-						. ' GitHub User: %2$s; GitHub Repo: %3$s; Issue Number: %4$s; State: %5$s, Old state: %6$s'
-						. '  The error message returned was: %7$s',
+						. ' GitHub User: %2$s; GitHub Repo: %3$s; Issue Number: %4$s; State: %5$s, Old state: %6$s',
 						$exception->getCode(),
 						$project->gh_user,
 						$project->gh_project,
 						$item->issue_number,
 						$state,
-						$oldState,
-						$exception->getMessage()
-					)
+						$oldState
+					),
+					['exception' => $exception]
 				);
 
-				throw new \RuntimeException('Invalid response from GitHub');
+				throw new \RuntimeException('Invalid response from GitHub', $exception->getCode(), $exception);
 			}
 
 			// Render the description text using GitHub's markdown renderer.

--- a/src/App/Tracker/Controller/Issue/Submit.php
+++ b/src/App/Tracker/Controller/Issue/Submit.php
@@ -234,18 +234,17 @@ class Submit extends AbstractTrackerController
 			$this->getContainer()->get('app')->getLogger()->error(
 				sprintf(
 					'Error code %1$s received from GitHub when creating an issue with the following data:'
-					. ' GitHub User: %2$s; GitHub Repo: %3$s; Title: %4$s; Body Text: %5$s'
-					. '  The error message returned was: %6$s',
+					. ' GitHub User: %2$s; GitHub Repo: %3$s; Title: %4$s; Body Text: %5$s',
 					$exception->getCode(),
 					$project->gh_user,
 					$project->gh_project,
 					$title,
-					$body,
-					$exception->getMessage()
-				)
+					$body
+				),
+				['exception' => $exception]
 			);
 
-			throw new \RuntimeException('Invalid response from GitHub');
+			throw new \RuntimeException('Invalid response from GitHub', $exception->getCode(), $exception);
 		}
 
 		/**

--- a/src/JTracker/Application.php
+++ b/src/JTracker/Application.php
@@ -260,11 +260,10 @@ final class Application extends AbstractWebApplication implements ContainerAware
 			// Log the error
 			$this->getLogger()->critical(
 				sprintf(
-					'Exception of type %1$s thrown with message %2$s',
-					get_class($exception),
-					$exception->getMessage()
+					'Exception of type %1$s thrown',
+					get_class($exception)
 				),
-				['trace' => $exception->getTraceAsString()]
+				['exception' => $exception]
 			);
 
 			$this->setHeader('Status', 500, true);

--- a/src/JTracker/Controller/AbstractAjaxController.php
+++ b/src/JTracker/Controller/AbstractAjaxController.php
@@ -56,11 +56,10 @@ abstract class AbstractAjaxController extends AbstractTrackerController
 			// Log the error
 			$this->getContainer()->get('app')->getLogger()->critical(
 				sprintf(
-					'Exception of type %1$s thrown with message %2$s',
-					get_class($e),
-					$e->getMessage()
+					'Exception of type %1$s thrown',
+					get_class($e)
 				),
-				['trace' => $e->getTraceAsString()]
+				['exception' => $e]
 			);
 
 			$this->response->error = $e->getMessage();


### PR DESCRIPTION
#### Summary of Changes

PSR-3 defines a standard for how Exceptions should be logged by attaching it to the context array of a log message.  Monolog supports this structure.  So, all places where Exceptions are being logged now attach the Exception to the context array (in the case of Monolog, the full Exception's data (type, message, code, and trace) get attached to log messages which actually makes these a bit more useful now.

Also changed a couple of places to chain Exceptions where there was a new Exception being thrown.

#### Testing Instructions

Trigger an error, validate Exception data is logged.  Or read the code and make sure I didn't screw this up.