### PR TITLE
App services layer

### DIFF
--- a/cli/Application/Application.php
+++ b/cli/Application/Application.php
@@ -28,6 +28,7 @@ use Joomla\DI\ContainerAwareInterface;
 use Joomla\DI\ContainerAwareTrait;
 use Joomla\Event\Dispatcher;
 use Joomla\Event\DispatcherAwareInterface;
+use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Input;
 use Joomla\Registry\Registry;
@@ -45,9 +46,9 @@ use JTracker\Service\TransifexProvider;
  *
  * @since  1.0
  */
-class Application extends AbstractCliApplication implements DispatcherAwareInterface
+class Application extends AbstractCliApplication implements ContainerAwareInterface, DispatcherAwareInterface
 {
-	use ContainerAwareTrait;
+	use ContainerAwareTrait, DispatcherAwareTrait;
 
 	/**
 	 * Quiet mode - no output.
@@ -88,14 +89,6 @@ class Application extends AbstractCliApplication implements DispatcherAwareInter
 	 * @since  1.0
 	 */
 	protected $commandOptions = array();
-
-	/**
-	 * Event Dispatcher
-	 *
-	 * @var    DispatcherInterface
-	 * @since  1.0
-	 */
-	private $dispatcher;
 
 	/**
 	 * Class constructor.
@@ -307,34 +300,6 @@ class Application extends AbstractCliApplication implements DispatcherAwareInter
 		}
 
 		return $alternatives;
-	}
-
-	/**
-	 * Get the dispatcher object.
-	 *
-	 * @return  DispatcherInterface
-	 *
-	 * @since   1.0
-	 */
-	public function getDispatcher()
-	{
-		return $this->dispatcher;
-	}
-
-	/**
-	 * Set the dispatcher to use.
-	 *
-	 * @param   DispatcherInterface  $dispatcher  The dispatcher to use.
-	 *
-	 * @return  $this  Method allows chaining
-	 *
-	 * @since   1.0
-	 */
-	public function setDispatcher(DispatcherInterface $dispatcher)
-	{
-		$this->dispatcher = $dispatcher;
-
-		return $this;
 	}
 
 	/**

--- a/src/App/Debug/DebugApp.php
+++ b/src/App/Debug/DebugApp.php
@@ -35,7 +35,7 @@ class DebugApp implements AppInterface
 
 		if (!$maps)
 		{
-			throw new \RuntimeException('Invalid router file for the Debug app.' . $path, 500);
+			throw new \RuntimeException('Invalid router file for the Debug app: ' . __DIR__ . '/routes.json', 500);
 		}
 
 		/** @var \JTracker\Application $application */

--- a/src/App/Debug/DebugApp.php
+++ b/src/App/Debug/DebugApp.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Debug Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Debug;
+
+use Joomla\DI\Container;
+use JTracker\AppInterface;
+
+/**
+ * Debug app
+ *
+ * @since  1.0
+ */
+class DebugApp implements AppInterface
+{
+	/**
+	 * Loads services for the component into the application's DI Container
+	 *
+	 * @param   Container  $container  DI Container to load services into
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function loadServices(Container $container)
+	{
+		// Register the component routes
+		$maps = json_decode(file_get_contents(__DIR__ . '/routes.json'), true);
+
+		if (!$maps)
+		{
+			throw new \RuntimeException('Invalid router file for the Debug app.' . $path, 500);
+		}
+
+		/** @var \JTracker\Application $application */
+		$application = $container->get('app');
+		$application->getRouter()->addMaps($maps);
+	}
+}

--- a/src/App/GitHub/GitHubApp.php
+++ b/src/App/GitHub/GitHubApp.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Part of the Joomla Tracker's GitHub Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\GitHub;
+
+use Joomla\DI\Container;
+use JTracker\AppInterface;
+
+/**
+ * GitHub app
+ *
+ * @since  1.0
+ */
+class GitHubApp implements AppInterface
+{
+	/**
+	 * Loads services for the component into the application's DI Container
+	 *
+	 * @param   Container  $container  DI Container to load services into
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function loadServices(Container $container)
+	{
+		// Register the component routes
+		$maps = json_decode(file_get_contents(__DIR__ . '/routes.json'), true);
+
+		if (!$maps)
+		{
+			throw new \RuntimeException('Invalid router file for the GitHub app.' . $path, 500);
+		}
+
+		/** @var \JTracker\Application $application */
+		$application = $container->get('app');
+		$application->getRouter()->addMaps($maps);
+	}
+}

--- a/src/App/Groups/GroupsApp.php
+++ b/src/App/Groups/GroupsApp.php
@@ -1,22 +1,22 @@
 <?php
 /**
- * Part of the Joomla Tracker's GitHub Application
+ * Part of the Joomla Tracker's Groups Application
  *
  * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 
-namespace App\GitHub;
+namespace App\Groups;
 
 use Joomla\DI\Container;
 use JTracker\AppInterface;
 
 /**
- * GitHub app
+ * Groups app
  *
  * @since  1.0
  */
-class GitHubApp implements AppInterface
+class GroupsApp implements AppInterface
 {
 	/**
 	 * Loads services for the component into the application's DI Container
@@ -35,7 +35,7 @@ class GitHubApp implements AppInterface
 
 		if (!$maps)
 		{
-			throw new \RuntimeException('Invalid router file for the GitHub app: ' . __DIR__ . '/routes.json', 500);
+			throw new \RuntimeException('Invalid router file for the Groups app: ' . __DIR__ . '/routes.json', 500);
 		}
 
 		/** @var \JTracker\Application $application */

--- a/src/App/Projects/ProjectsApp.php
+++ b/src/App/Projects/ProjectsApp.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Projects Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Projects;
+
+use Joomla\DI\Container;
+use JTracker\AppInterface;
+
+/**
+ * Projects app
+ *
+ * @since  1.0
+ */
+class ProjectsApp implements AppInterface
+{
+	/**
+	 * Loads services for the component into the application's DI Container
+	 *
+	 * @param   Container  $container  DI Container to load services into
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function loadServices(Container $container)
+	{
+		// Register the component routes
+		$maps = json_decode(file_get_contents(__DIR__ . '/routes.json'), true);
+
+		if (!$maps)
+		{
+			throw new \RuntimeException('Invalid router file for the Projects app.' . $path, 500);
+		}
+
+		/** @var \JTracker\Application $application */
+		$application = $container->get('app');
+		$application->getRouter()->addMaps($maps);
+	}
+}

--- a/src/App/Projects/ProjectsApp.php
+++ b/src/App/Projects/ProjectsApp.php
@@ -35,7 +35,7 @@ class ProjectsApp implements AppInterface
 
 		if (!$maps)
 		{
-			throw new \RuntimeException('Invalid router file for the Projects app.' . $path, 500);
+			throw new \RuntimeException('Invalid router file for the Projects app: ' . __DIR__ . '/routes.json', 500);
 		}
 
 		/** @var \JTracker\Application $application */

--- a/src/App/Support/SupportApp.php
+++ b/src/App/Support/SupportApp.php
@@ -35,7 +35,7 @@ class SupportApp implements AppInterface
 
 		if (!$maps)
 		{
-			throw new \RuntimeException('Invalid router file for the Support app.' . $path, 500);
+			throw new \RuntimeException('Invalid router file for the Support app: ' . __DIR__ . '/routes.json', 500);
 		}
 
 		/** @var \JTracker\Application $application */

--- a/src/App/Support/SupportApp.php
+++ b/src/App/Support/SupportApp.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Support Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Support;
+
+use Joomla\DI\Container;
+use JTracker\AppInterface;
+
+/**
+ * Support app
+ *
+ * @since  1.0
+ */
+class SupportApp implements AppInterface
+{
+	/**
+	 * Loads services for the component into the application's DI Container
+	 *
+	 * @param   Container  $container  DI Container to load services into
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function loadServices(Container $container)
+	{
+		// Register the component routes
+		$maps = json_decode(file_get_contents(__DIR__ . '/routes.json'), true);
+
+		if (!$maps)
+		{
+			throw new \RuntimeException('Invalid router file for the Support app.' . $path, 500);
+		}
+
+		/** @var \JTracker\Application $application */
+		$application = $container->get('app');
+		$application->getRouter()->addMaps($maps);
+	}
+}

--- a/src/App/System/SystemApp.php
+++ b/src/App/System/SystemApp.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Part of the Joomla Tracker's System Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\System;
+
+use Joomla\DI\Container;
+use JTracker\AppInterface;
+
+/**
+ * System app
+ *
+ * @since  1.0
+ */
+class SystemApp implements AppInterface
+{
+	/**
+	 * Loads services for the component into the application's DI Container
+	 *
+	 * @param   Container  $container  DI Container to load services into
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function loadServices(Container $container)
+	{
+		// Register the component routes
+		$maps = json_decode(file_get_contents(__DIR__ . '/routes.json'), true);
+
+		if (!$maps)
+		{
+			throw new \RuntimeException('Invalid router file for the System app.' . $path, 500);
+		}
+
+		/** @var \JTracker\Application $application */
+		$application = $container->get('app');
+		$application->getRouter()->addMaps($maps);
+	}
+}

--- a/src/App/System/SystemApp.php
+++ b/src/App/System/SystemApp.php
@@ -35,7 +35,7 @@ class SystemApp implements AppInterface
 
 		if (!$maps)
 		{
-			throw new \RuntimeException('Invalid router file for the System app.' . $path, 500);
+			throw new \RuntimeException('Invalid router file for the System app: ' . __DIR__ . '/routes.json', 500);
 		}
 
 		/** @var \JTracker\Application $application */

--- a/src/App/Text/TextApp.php
+++ b/src/App/Text/TextApp.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Text Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Text;
+
+use Joomla\DI\Container;
+use JTracker\AppInterface;
+
+/**
+ * Text app
+ *
+ * @since  1.0
+ */
+class TextApp implements AppInterface
+{
+	/**
+	 * Loads services for the component into the application's DI Container
+	 *
+	 * @param   Container  $container  DI Container to load services into
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function loadServices(Container $container)
+	{
+		// Register the component routes
+		$maps = json_decode(file_get_contents(__DIR__ . '/routes.json'), true);
+
+		if (!$maps)
+		{
+			throw new \RuntimeException('Invalid router file for the Text app.' . $path, 500);
+		}
+
+		/** @var \JTracker\Application $application */
+		$application = $container->get('app');
+		$application->getRouter()->addMaps($maps);
+	}
+}

--- a/src/App/Text/TextApp.php
+++ b/src/App/Text/TextApp.php
@@ -35,7 +35,7 @@ class TextApp implements AppInterface
 
 		if (!$maps)
 		{
-			throw new \RuntimeException('Invalid router file for the Text app.' . $path, 500);
+			throw new \RuntimeException('Invalid router file for the Text app: ' . __DIR__ . '/routes.json', 500);
 		}
 
 		/** @var \JTracker\Application $application */

--- a/src/App/Tracker/TrackerApp.php
+++ b/src/App/Tracker/TrackerApp.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Tracker Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Tracker;
+
+use Joomla\DI\Container;
+use JTracker\AppInterface;
+
+/**
+ * Tracker app
+ *
+ * @since  1.0
+ */
+class TrackerApp implements AppInterface
+{
+	/**
+	 * Loads services for the component into the application's DI Container
+	 *
+	 * @param   Container  $container  DI Container to load services into
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function loadServices(Container $container)
+	{
+		// Register the component routes
+		$maps = json_decode(file_get_contents(__DIR__ . '/routes.json'), true);
+
+		if (!$maps)
+		{
+			throw new \RuntimeException('Invalid router file for the Tracker app.' . $path, 500);
+		}
+
+		/** @var \JTracker\Application $application */
+		$application = $container->get('app');
+		$application->getRouter()->addMaps($maps);
+	}
+}

--- a/src/App/Tracker/TrackerApp.php
+++ b/src/App/Tracker/TrackerApp.php
@@ -35,7 +35,7 @@ class TrackerApp implements AppInterface
 
 		if (!$maps)
 		{
-			throw new \RuntimeException('Invalid router file for the Tracker app.' . $path, 500);
+			throw new \RuntimeException('Invalid router file for the Tracker app: ' . __DIR__ . '/routes.json', 500);
 		}
 
 		/** @var \JTracker\Application $application */

--- a/src/App/Users/UsersApp.php
+++ b/src/App/Users/UsersApp.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Users Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Users;
+
+use Joomla\DI\Container;
+use JTracker\AppInterface;
+
+/**
+ * Users app
+ *
+ * @since  1.0
+ */
+class UsersApp implements AppInterface
+{
+	/**
+	 * Loads services for the component into the application's DI Container
+	 *
+	 * @param   Container  $container  DI Container to load services into
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function loadServices(Container $container)
+	{
+		// Register the component routes
+		$maps = json_decode(file_get_contents(__DIR__ . '/routes.json'), true);
+
+		if (!$maps)
+		{
+			throw new \RuntimeException('Invalid router file for the Users app.' . $path, 500);
+		}
+
+		/** @var \JTracker\Application $application */
+		$application = $container->get('app');
+		$application->getRouter()->addMaps($maps);
+	}
+}

--- a/src/App/Users/UsersApp.php
+++ b/src/App/Users/UsersApp.php
@@ -35,7 +35,7 @@ class UsersApp implements AppInterface
 
 		if (!$maps)
 		{
-			throw new \RuntimeException('Invalid router file for the Users app.' . $path, 500);
+			throw new \RuntimeException('Invalid router file for the Users app: ' . __DIR__ . '/routes.json', 500);
 		}
 
 		/** @var \JTracker\Application $application */

--- a/src/JTracker/AppInterface.php
+++ b/src/JTracker/AppInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Part of the Joomla Tracker
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace JTracker;
+
+use Joomla\DI\Container;
+
+/**
+ * Interface defining a Joomla! Issue Tracker App
+ *
+ * @since  1.0
+ */
+interface AppInterface
+{
+	/**
+	 * Loads services for the component into the application's DI Container
+	 *
+	 * @param   Container  $container  DI Container to load services into
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function loadServices(Container $container);
+}

--- a/src/JTracker/Application.php
+++ b/src/JTracker/Application.php
@@ -22,6 +22,7 @@ use Joomla\Event\Dispatcher;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Registry\Registry;
+use Joomla\Router\Router;
 
 use JTracker\Authentication\Exception\AuthenticationException;
 use JTracker\Authentication\GitHub\GitHubLoginHelper;
@@ -49,7 +50,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
  */
 final class Application extends AbstractWebApplication implements ContainerAwareInterface, DispatcherAwareInterface
 {
-	use ContainerAwareTrait, DispatcherAwareTrait;
+	use ContainerAwareTrait, DispatcherAwareTrait, ApplicationTrait;
 
 	/**
 	 * The name of the application.
@@ -67,6 +68,14 @@ final class Application extends AbstractWebApplication implements ContainerAware
 	 * @note   This has been created to avoid a conflict with the $session member var from the parent class.
 	 */
 	private $newSession = null;
+
+	/**
+	 * Application router.
+	 *
+	 * @var    Router
+	 * @since  1.0
+	 */
+	private $router;
 
 	/**
 	 * The User object.
@@ -124,6 +133,8 @@ final class Application extends AbstractWebApplication implements ContainerAware
 				]
 			)
 		);
+
+		$this->setRouter(new TrackerRouter($this->getContainer(), $this->input));
 	}
 
 	/**
@@ -149,47 +160,24 @@ final class Application extends AbstractWebApplication implements ContainerAware
 	{
 		try
 		{
-			// Instantiate the router
-			$router = new TrackerRouter($this->getContainer(), $this->input);
+			$this->getRouter()->setControllerPrefix('\\App')
+				->setDefaultController('\\Tracker\\Controller\\DefaultController');
 
-			// Search for App specific routes
-			/* @type \DirectoryIterator $fileInfo */
-			foreach (new \DirectoryIterator(JPATH_ROOT . '/src/App') as $fileInfo)
-			{
-				if ($fileInfo->isDot())
-				{
-					continue;
-				}
+			$this->bootApps();
 
-				$path = realpath(JPATH_ROOT . '/src/App/' . $fileInfo->getFilename() . '/routes.json');
-
-				if ($path)
-				{
-					$maps = json_decode(file_get_contents($path));
-
-					if (!$maps)
-					{
-						throw new \RuntimeException('Invalid router file. ' . $path, 500);
-					}
-
-					$router->addMaps($maps);
-				}
-			}
-
-			$router->setControllerPrefix('\\App');
-			$router->setDefaultController('\\Tracker\\Controller\\DefaultController');
+			$this->mark('Apps booted');
 
 			// Fetch the controller
 			/* @type AbstractTrackerController $controller */
-			$controller = $router->getController($this->get('uri.route'));
+			$controller = $this->getRouter()->getController($this->get('uri.route'));
 
-			$this->mark('Controller->initialize()');
 			$controller->initialize();
+			$this->mark('Controller initialized');
 
 			// Load the language for the application
 			// @todo language must be loaded after routing is processed cause the Project object is coupled with the User object...
-			$this->mark('loadLanguage()');
 			$this->loadLanguage();
+			$this->mark('Language loaded');
 
 			// Execute the App
 
@@ -199,9 +187,8 @@ final class Application extends AbstractWebApplication implements ContainerAware
 			// Load the App language file
 			g11n::loadLanguage($controller->getApp(), 'App');
 
-			$this->mark('Controller->execute()');
-
 			$contents = $controller->execute();
+			$this->mark('Controller executed');
 
 			if (!$contents)
 			{
@@ -722,5 +709,39 @@ final class Application extends AbstractWebApplication implements ContainerAware
 		$this->input->cookie->set('remember_me', $value, $expire);
 
 		return $this;
+	}
+
+	/**
+	 * Set the application's router.
+	 *
+	 * @param   Router  $router  Router object to set.
+	 *
+	 * @return  $this
+	 *
+	 * @since   1.0
+	 */
+	public function setRouter(Router $router)
+	{
+		$this->router = $router;
+
+		return $this;
+	}
+
+	/**
+	 * Get the event dispatcher.
+	 *
+	 * @return  Router
+	 *
+	 * @since   1.0
+	 * @throws  \UnexpectedValueException May be thrown if the router has not been set.
+	 */
+	public function getRouter()
+	{
+		if ($this->router)
+		{
+			return $this->router;
+		}
+
+		throw new \UnexpectedValueException('Router not set in ' . __CLASS__);
 	}
 }

--- a/src/JTracker/Application.php
+++ b/src/JTracker/Application.php
@@ -247,7 +247,7 @@ final class Application extends AbstractWebApplication implements ContainerAware
 				['exception' => $exception]
 			);
 
-			$this->setHeader('Status', 500, true);
+			$this->setErrorHeader($exception);
 
 			$this->mark('Application terminated with an EXCEPTION');
 
@@ -743,5 +743,46 @@ final class Application extends AbstractWebApplication implements ContainerAware
 		}
 
 		throw new \UnexpectedValueException('Router not set in ' . __CLASS__);
+	}
+
+	/**
+	 * Set the HTTP Response Header for error conditions
+	 *
+	 * @param   \Exception  $exception  The Exception object
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	private function setErrorHeader(\Exception $exception)
+	{
+		switch ($exception->getCode())
+		{
+			case 401 :
+				$this->setHeader('HTTP/1.1 401 Unauthorized', 401, true);
+
+				break;
+
+			case 403 :
+				$this->setHeader('HTTP/1.1 403 Forbidden', 403, true);
+
+				break;
+
+			case 404 :
+				$this->setHeader('HTTP/1.1 404 Not Found', 404, true);
+
+				break;
+
+			case 405 :
+				$this->setHeader('HTTP/1.1 405 Method Not Allowed', 405, true);
+
+				break;
+
+			case 500 :
+			default  :
+				$this->setHeader('HTTP/1.1 500 Internal Server Error', 500, true);
+
+				break;
+		}
 	}
 }

--- a/src/JTracker/ApplicationTrait.php
+++ b/src/JTracker/ApplicationTrait.php
@@ -10,6 +10,8 @@ namespace JTracker;
 
 /**
  * Trait defining common methods between application classes
+ *
+ * @since  1.0
  */
 trait ApplicationTrait
 {

--- a/src/JTracker/ApplicationTrait.php
+++ b/src/JTracker/ApplicationTrait.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Part of the Joomla Tracker
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace JTracker;
+
+/**
+ * Trait defining common methods between application classes
+ */
+trait ApplicationTrait
+{
+	/**
+	 * Loads the application's apps
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	protected function bootApps()
+	{
+		// Find all components and if they have a AppInterface implementation load their services
+		/** @var \DirectoryIterator $fileInfo */
+		foreach (new \DirectoryIterator(JPATH_ROOT . '/src/App') as $fileInfo)
+		{
+			if ($fileInfo->isDot())
+			{
+				continue;
+			}
+
+			$className = 'App\\' . $fileInfo->getFilename() . '\\' . $fileInfo->getFilename() . 'App';
+
+			if (class_exists($className))
+			{
+				/** @var AppInterface $object */
+				$object = new $className;
+
+				// Register the app services
+				$object->loadServices($this->getContainer());
+			}
+		}
+	}
+}


### PR DESCRIPTION
#### Summary of Changes

This creates an `AppInterface` and base app classes for each of the apps in the overall application.  Compare this to a really simplified version of Symfony bundles.  Long and short it allows each app to load its services into the application structure.  The loading of routes for the router is moved into this layer instead of directly in the application class now.

This layer should be used to help be able to create a more service injection based approach to things versus a service locator approach that's used now.  It also sets up a way to be able to set up the command line environment to be able to use the apps' APIs the same way the web app does.

#### Testing Instructions

Everything still works.