### PR TITLE
Skip mime validation for txt files

### DIFF
--- a/src/JTracker/Upload/File.php
+++ b/src/JTracker/Upload/File.php
@@ -83,11 +83,18 @@ class File extends UploadFile implements \JsonSerializable
 	 */
 	private function setValidations()
 	{
-		$this->addValidations(
-			array(
-				new Mimetype($this->application->get('validation.mime_types')),
-				new Size($this->application->get('validation.file_size'))
-			)
-		);
+		$validations = [
+			new Mimetype($this->application->get('validation.mime_types')),
+			new Size($this->application->get('validation.file_size'))
+		];
+
+		// Txt has mime inconsistency on different environments,
+		// so do not set mime validation for it.
+		if ($this->getExtension() == 'txt')
+		{
+			array_shift($validations);
+		}
+
+		$this->addValidations($validations);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #760.

#### Summary of Changes

This will skip `txt` files mime validation.

#### Testing Instructions

Use my [testing server](http://jtracker.j4devs.ru/tracker/jissues-test/) and try to upload Joomla's system info file. It should upload fine.

