### PR TITLE
Session language

### DIFF
--- a/src/JTracker/Application.php
+++ b/src/JTracker/Application.php
@@ -89,7 +89,7 @@ final class Application extends AbstractWebApplication implements ContainerAware
 	 * @var    string
 	 * @since  1.0
 	 */
-	private $languageTag;
+	private $languageTag = 'en-GB';
 
 	/**
 	 * Class constructor.
@@ -378,6 +378,8 @@ final class Application extends AbstractWebApplication implements ContainerAware
 		{
 			// Set the current language if anything has been found.
 			g11n::setCurrent($lang);
+
+			$this->languageTag = $lang;
 		}
 
 		// Set language debugging.

--- a/src/JTracker/Application.php
+++ b/src/JTracker/Application.php
@@ -84,6 +84,14 @@ final class Application extends AbstractWebApplication implements ContainerAware
 	private $project;
 
 	/**
+	 * The current language in use. E.g. "en-GB".
+	 *
+	 * @var    string
+	 * @since  1.0
+	 */
+	private $languageTag;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   Session   $session  The application's session object
@@ -98,6 +106,18 @@ final class Application extends AbstractWebApplication implements ContainerAware
 		parent::__construct($input, $config);
 
 		$this->newSession = $session;
+	}
+
+	/**
+	 * Get the current language tag. E.g. en-GB.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getLanguageTag()
+	{
+		return $this->languageTag;
 	}
 
 	/**
@@ -345,8 +365,13 @@ final class Application extends AbstractWebApplication implements ContainerAware
 		}
 		else
 		{
-			// Get the language tag from the user params or session. Default to British.
-			$lang = $this->getUser()->params->get('language', $this->getSession()->get('lang', 'en-GB'));
+			/*
+			 * Get the language tag:
+			 * 1. From the session
+			 * 2. From the user param
+			 * 3. Default to British
+			 */
+			$lang = $this->getSession()->get('lang', $this->getUser()->params->get('language', 'en-GB'));
 		}
 
 		if ($lang)

--- a/src/JTracker/View/Renderer/TrackerExtension.php
+++ b/src/JTracker/View/Renderer/TrackerExtension.php
@@ -84,7 +84,7 @@ class TrackerExtension extends \Twig_Extension implements \Twig_Extension_Global
 			'languageCodes'  => LanguageHelper::getLanguageCodes(),
 			'jdebug'         => JDEBUG,
 			'templateDebug'  => $this->app->get('debug.template', false),
-			'lang'           => $this->app->getUser()->params->get('language') ?: g11n::getCurrent(),
+			'lang'           => $this->app->getLanguageTag(),
 			'g11nJavaScript' => g11n::getJavaScript(),
 			'useCDN'         => $this->app->get('system.use_cdn'),
 		];


### PR DESCRIPTION
Fix #806

**Bug**: The `users language` parameter (if set) overrides the `session language` parameter (if set) causing the current language to be "resetted" to the users parameter language.

This happens if the following criteria are met:

1. You are logged in.
1. You have set a language in you user settings (in jissues)
1. This language is different from the one you are selecting using the language selector.

#### Summary of Changes
The Application class now has a method to get the current language tag.

Now the language code present in the session (if so) is preferred over the user parameter. I **guess** that this should be the right behaviour.

**Note**: While I completely dislike adding even more code to the Application class, I swear that I will move the `loadLanguage()` method to the `LanguageHelper` class "soonish" :tongue: 

#### Testing Instructions

Check that the erroneous behaviour described in #806 is fixed.

@b2z would you mind checking that nothing broke with the user param please?