### PR TITLE
Fix for the RWD of users search

### DIFF
--- a/www/media/css/jtracker.css
+++ b/www/media/css/jtracker.css
@@ -291,6 +291,15 @@ li.lang-select .ui.active.search.dropdown>input.search:focus+.text {
     #filter-state-div .btn {
         width: 33.33%;
     }
+    
+    .form-search .input-append .btn {
+        width: auto;
+    }
+    
+    #filtersForm .btn-group {
+        margin: 0 5px;
+        width: auto;
+    }
 
     .well-small.user-wrapper > .avatar {
         float: left;


### PR DESCRIPTION
For screen up to 767px, the display of the icon search and clear button are incorrect, creating an horizontal scrolling.

### Expected result
![after](https://cloud.githubusercontent.com/assets/4682328/16709739/427dbeb2-45e7-11e6-9c36-e8132af65bda.png)

### Current result
![before](https://cloud.githubusercontent.com/assets/4682328/16709741/4b4466a4-45e7-11e6-8a8d-4e3a3a6fdfd7.png)

