### PR TITLE
Refresh User's name and sync with Github profile

### DIFF
--- a/src/App/Users/Controller/User/Refresh.php
+++ b/src/App/Users/Controller/User/Refresh.php
@@ -78,6 +78,17 @@ class Refresh extends AbstractTrackerController
 			);
 		}
 
+		try
+		{
+			$loginHelper->setName($user->username, $gitHubUser->name);
+		}
+		catch (\RuntimeException $e)
+		{
+			$application->enqueueMessage(
+				g11n3t('An error has occurred during name refresh.'), 'error'
+			);
+		}
+
 		$application->enqueueMessage(
 			g11n3t('The profile has been refreshed.'), 'success'
 		)

--- a/src/JTracker/Authentication/GitHub/GitHubLoginHelper.php
+++ b/src/JTracker/Authentication/GitHub/GitHubLoginHelper.php
@@ -302,6 +302,29 @@ class GitHubLoginHelper
 	}
 
 	/**
+	 * Set the name for a user
+	 *
+	 * @param   integer  $userName  The username to update
+	 * @param   string   $name      The name to set
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function setName($userName, $name = '')
+	{
+		/* @type \Joomla\Database\DatabaseDriver $db */
+		$db = $this->container->get('db');
+
+		$db->setQuery(
+			$db->getQuery(true)
+				->update($db->quoteName('#__users'))
+				->set($db->quoteName('name') . '=' . $db->quote($name))
+				->where($db->quoteName('username') . '=' . $db->quote($userName))
+		)->execute();
+	}
+
+	/**
 	 * Set the last visited time for a newly logged in user
 	 *
 	 * @param   integer  $id  The user ID to update


### PR DESCRIPTION
#### Summary of Changes
Refresh user's name

#### Testing Instructions
Before it was not possible to refresh the user's name from Github.
After it will be possible to refresh the user's name

