### PR TITLE
G11n named parameters

### DIFF
--- a/cli/Application/Command/Export/Langfiles.php
+++ b/cli/Application/Command/Export/Langfiles.php
@@ -121,7 +121,7 @@ class Langfiles extends Export
 
 		$filesystem = new Filesystem(new Local($this->exportDir . '/' . $domainBase . '/' . $extension . '/' . $g11nPath));
 
-		$this->out(sprintf(g11n3t('Processing %1$s %2$s:... '), $domain, $extension), false);
+		$this->out(g11n3t('Processing %domain% %extension%... ', ['%domain%' => $domain, '%extension%' => $extension]), false);
 
 		// Process language templates
 		if ($templates)

--- a/cli/Application/Command/Get/Languagefiles.php
+++ b/cli/Application/Command/Get/Languagefiles.php
@@ -129,7 +129,7 @@ class Languagefiles extends Get
 	 */
 	private function receiveFiles($extension, $domain)
 	{
-		$this->out(sprintf(g11n3t('Processing: %1$s %2$s... '), $domain, $extension), false);
+		$this->out(g11n3t('Processing %domain% %extension%... ', ['%domain%' => $domain, '%extension%' => $extension]), false);
 
 		$scopePath     = ExtensionHelper::getDomainPath($domain);
 		$extensionPath = ExtensionHelper::getExtensionLanguagePath($extension);

--- a/cli/Application/Command/Get/Project.php
+++ b/cli/Application/Command/Get/Project.php
@@ -121,10 +121,8 @@ class Project extends Get
 			->setupGitHub()
 			->displayGitHubRateLimit()
 			->out(
-				sprintf(
-					g11n3t('Updating project info for project: %1$s/%2$s'),
-					$this->project->gh_user,
-					$this->project->gh_project
+				g11n3t('Updating project info for project: %user%/%project%',
+					['%user%' => $this->project->gh_user, '%project%' => $this->project->gh_project]
 				)
 			)
 			->processLabels()

--- a/cli/Application/Command/Make/Depfile.php
+++ b/cli/Application/Command/Make/Depfile.php
@@ -255,7 +255,7 @@ class Depfile extends Make
 				{
 					$path = g11nExtensionHelper::findLanguageFile($langTag, $extension, $domain);
 
-					if (true === file_exists($path))
+					if (false === file_exists($path))
 					{
 						$this->out(
 							g11n3t(

--- a/cli/Application/Command/Make/Depfile.php
+++ b/cli/Application/Command/Make/Depfile.php
@@ -255,9 +255,14 @@ class Depfile extends Make
 				{
 					$path = g11nExtensionHelper::findLanguageFile($langTag, $extension, $domain);
 
-					if (false === file_exists($path))
+					if (true === file_exists($path))
 					{
-						$this->out(sprintf(g11n3t('Language file not found %1$s, %2$s, %3$s'), $langTag, $extension, $domain));
+						$this->out(
+							g11n3t(
+							'Language file not found: %tag%, %extension%, %domain%',
+							['%tag%' => $langTag, '%domain%' => $domain, '%extension%' => $extension]
+							)
+						);
 
 						continue;
 					}

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "joomla/view": "~2.0@dev",
         "symfony/http-foundation": "2.8.*",
         "twig/twig": "~1.23",
-        "elkuku/g11n": "dev-master",
+        "elkuku/g11n": "~2.0",
         "elkuku/console-progressbar": "1.0",
         "elkuku/crowdin-api": "~1.0",
         "babdev/transifex": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "joomla/view": "~2.0@dev",
         "symfony/http-foundation": "2.8.*",
         "twig/twig": "~1.23",
-        "elkuku/g11n": "~2.4",
+        "elkuku/g11n": "dev-master",
         "elkuku/console-progressbar": "1.0",
         "elkuku/crowdin-api": "~1.0",
         "babdev/transifex": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "97068aefac6343c7da6522a78b90c35d",
-    "content-hash": "b89c8dcb3fb6b06c757f478e170978ff",
+    "hash": "06b0a4fc084bf9b4a1dee00826d3eb45",
+    "content-hash": "eaf060e3a0b51690654c385dc6cf70ae",
     "packages": [
         {
             "name": "adaptive/php-text-difference",
@@ -233,16 +233,16 @@
         },
         {
             "name": "elkuku/g11n",
-            "version": "2.4",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elkuku/g11n.git",
-                "reference": "026932fb3a430689c3fd3a96d7bbe4fb6b850f3c"
+                "reference": "b343632d5b7ffb43c18e5eef2829526ad2606085"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elkuku/g11n/zipball/026932fb3a430689c3fd3a96d7bbe4fb6b850f3c",
-                "reference": "026932fb3a430689c3fd3a96d7bbe4fb6b850f3c",
+                "url": "https://api.github.com/repos/elkuku/g11n/zipball/b343632d5b7ffb43c18e5eef2829526ad2606085",
+                "reference": "b343632d5b7ffb43c18e5eef2829526ad2606085",
                 "shasum": ""
             },
             "require": {
@@ -266,7 +266,7 @@
                 }
             ],
             "description": "The g11n language library",
-            "time": "2016-06-19 13:59:08"
+            "time": "2016-07-13 16:56:31"
         },
         {
             "name": "filp/whoops",
@@ -3878,7 +3878,8 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "joomla/renderer": 20,
-        "joomla/view": 20
+        "joomla/view": 20,
+        "elkuku/g11n": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "06b0a4fc084bf9b4a1dee00826d3eb45",
-    "content-hash": "eaf060e3a0b51690654c385dc6cf70ae",
+    "hash": "fa694a0b2d79304f61bf6b8f24bd98cc",
+    "content-hash": "f83b3daff03fa9668396bef0fcb07336",
     "packages": [
         {
             "name": "adaptive/php-text-difference",
@@ -233,21 +233,25 @@
         },
         {
             "name": "elkuku/g11n",
-            "version": "dev-master",
+            "version": "2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elkuku/g11n.git",
-                "reference": "b343632d5b7ffb43c18e5eef2829526ad2606085"
+                "reference": "b6004a86a51b94a42ff80ec2e41155cdd036e0a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elkuku/g11n/zipball/b343632d5b7ffb43c18e5eef2829526ad2606085",
-                "reference": "b343632d5b7ffb43c18e5eef2829526ad2606085",
+                "url": "https://api.github.com/repos/elkuku/g11n/zipball/b6004a86a51b94a42ff80ec2e41155cdd036e0a5",
+                "reference": "b6004a86a51b94a42ff80ec2e41155cdd036e0a5",
                 "shasum": ""
             },
             "require": {
                 "league/flysystem": "1.*",
-                "php": ">=5.3.10"
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
             },
             "type": "library",
             "autoload": {
@@ -266,7 +270,7 @@
                 }
             ],
             "description": "The g11n language library",
-            "time": "2016-07-13 16:56:31"
+            "time": "2016-07-13 22:29:54"
         },
         {
             "name": "filp/whoops",
@@ -3878,8 +3882,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "joomla/renderer": 20,
-        "joomla/view": 20,
-        "elkuku/g11n": 20
+        "joomla/view": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/JTracker/View/Renderer/TrackerExtension.php
+++ b/src/JTracker/View/Renderer/TrackerExtension.php
@@ -101,6 +101,7 @@ class TrackerExtension extends \Twig_Extension implements \Twig_Extension_Global
 	{
 		$functions = [
 			new \Twig_SimpleFunction('translate', 'g11n3t'),
+			new \Twig_SimpleFunction('_', 'g11n3t'),
 			new \Twig_SimpleFunction('g11n4t', 'g11n4t'),
 			new \Twig_SimpleFunction('sprintf', 'sprintf'),
 			new \Twig_SimpleFunction('stripJRoot', [$this, 'stripJRoot']),

--- a/templates/footerMenu.twig
+++ b/templates/footerMenu.twig
@@ -41,6 +41,6 @@
 
     <div class="hosting">
         <div class="hosting-image"><a href="https://www.rochen.com/joomla-hosting" target="_blank"><img class="rochen" src="https://cdn.joomla.org/rochen/rochen_footer_logo_white.png" alt="Rochen" /></a></div>
-        <div class="hosting-text"><a href="https://www.rochen.com/joomla-hosting" target="_blank">{{ sprintf("Joomla! Hosting by %1$s"|_, "Rochen") }}</a></div>
+        <div class="hosting-text"><a href="https://www.rochen.com/joomla-hosting" target="_blank">{{ _('Joomla! Hosting by %provider%', {'%provider%' : 'Rochen'}) }}</a></div>
     </div>
 </div>

--- a/templates/tracker/issue.add.twig
+++ b/templates/tracker/issue.add.twig
@@ -51,7 +51,10 @@
                 {{ fields.select('priority', priorities, item.priority, 'priority', 'input-small-100') }}
 
                 <div class="helpText alert alert-info">
-                    {{ "The priority of which this issue should be resolved. Please see the <a class=\"alert-link\" href=\"https://docs.joomla.org/Bug_Tracking_Process\" target=\"blank\">Bug Tracking Process</a> page for detailed information about the project's priorities."|_|raw }}
+                    {{ _(
+                    "The priority of which this issue should be resolved. Please see the <a %class% href=\"https://docs.joomla.org/Bug_Tracking_Process\" target=\"blank\">Bug Tracking Process</a> page for detailed information about the project's priorities.",
+                    {"%class%" : "class=\"alert-link\""}
+                    )|raw }}
                 </div>
 
                 {{ fields.label('build', 'Build'|_, '') }}
@@ -87,7 +90,10 @@
             <div class="span9 issue-add-details">
 
                 <div class="alert alert-warning">
-                    {{ "Report security issues to the Joomla! Security Strike Team (JSST) at <a class=\"alert-link\" href=\"mailto:security@joomla.org\">security@joomla.org</a> or with the <a class=\"alert-link\" href=\"https://developer.joomla.org/contact-security-team.html\">JSST contact form</a>, please do not use the public tracker for security issues."|_|raw }}
+                    {{ _(
+                    "Report security issues to the Joomla! Security Strike Team (JSST) at <a %class1% %href1%>security@joomla.org</a> or with the <a %class2% %href2%>JSST contact form</a>, please do not use the public tracker for security issues.",
+                    {"%class1%" : "class=\"alert-link\"", "%href1%" : "href=\"mailto:security@joomla.org\"", "%class2%" : "class=\"alert-link\"", "%href2" : "href=\"https://developer.joomla.org/contact-security-team.html\""}
+                    )|raw }}
                 </div>
 
                 <div class="helpText alert alert-info">


### PR DESCRIPTION
#### Summary of Changes
Here are some changes required to use named parameters in translation strings, supported as of version 2.5 of the g11n library.

<del>For some unknown reason (to me) the tag/release does not appear on [Packagist](https://packagist.org/packages/elkuku/g11n) so I used `dev-master` in the composer file.</del>PEBKAC

#### Testing Instructions

Write lots of translatable strings with named parameters :wink: 