### PR TITLE
Add php-cs-fixer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ cache.properties
 build/api/*
 build/logs/*
 current_SHA
+/.php_cs.cache
 
 # Ignore uploads #
 www/uploads/*

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,57 @@
+<?php
+
+return Symfony\CS\Config\Config::create()
+	->setUsingLinter(false)
+	->setUsingCache(true)
+	->level(Symfony\CS\FixerInterface::NONE_LEVEL)
+	->fixers(
+		[
+			// psr-1
+			'encoding',
+			// psr-2
+			'elseif',
+			'eof_ending',
+			'function_call_space',
+			'line_after_namespace',
+			'linefeed',
+			'lowercase_constants',
+			'lowercase_keywords',
+			'method_argument_space',
+			'multiple_use',
+			'parenthesis',
+			'single_line_after_imports',
+			'trailing_spaces',
+			'visibility',
+			// symfony
+			'array_element_no_space_before_comma',
+			'array_element_white_space_after_comma',
+			'duplicate_semicolon',
+			'empty_return',
+			'extra_empty_lines',
+			'function_typehint_space',
+			'include',
+			'join_function',
+			'list_commas',
+			'multiline_array_trailing_comma',
+			'no_blank_lines_after_class_opening',
+			'phpdoc_trim',
+			'return',
+			'single_array_no_trailing_comma',
+			'single_blank_line_before_namespace',
+			'spaces_cast',
+			'unneeded_control_parentheses',
+			'unused_use',
+			'whitespacy_lines',
+			// contrib
+			'concat_with_spaces',
+			'short_array_syntax',
+		]
+	)
+	->finder(
+		Symfony\CS\Finder\DefaultFinder::create()->in(
+			[
+				__DIR__ . '/src',
+				__DIR__ . '/cli',
+			]
+		)
+	);

--- a/cli/Application/Command/Get/Project/Events.php
+++ b/cli/Application/Command/Get/Project/Events.php
@@ -12,7 +12,6 @@ use App\Projects\TrackerProject;
 use App\Tracker\Table\ActivitiesTable;
 
 use Application\Command\Get\Project;
-use Application\Command\TrackerCommandOption;
 
 use Joomla\Date\Date;
 

--- a/cli/Application/Command/Get/Project/Labels.php
+++ b/cli/Application/Command/Get/Project/Labels.php
@@ -85,7 +85,7 @@ class Labels extends Project
 				$table->load(
 					[
 						'project_id' => $this->project->project_id,
-						'name'       => $label->name
+						'name'       => $label->name,
 					]
 				);
 

--- a/cli/Application/Command/Get/Project/Milestones.php
+++ b/cli/Application/Command/Get/Project/Milestones.php
@@ -92,7 +92,7 @@ class Milestones extends Project
 				$table->load(
 					[
 						'project_id' => $this->project->project_id,
-						'milestone_number' => $milestone->number
+						'milestone_number' => $milestone->number,
 					]
 				);
 

--- a/cli/Application/Command/Make/Langtemplates.php
+++ b/cli/Application/Command/Make/Langtemplates.php
@@ -168,7 +168,7 @@ class Langtemplates extends Make
 
 			$paths = [
 				ExtensionHelper::getDomainPath($domain),
-				JPATH_ROOT . '/src/App'
+				JPATH_ROOT . '/src/App',
 			];
 
 			$this->processTemplates($extension, $domain, 'php', $paths, $templatePath);
@@ -468,7 +468,7 @@ class Langtemplates extends Make
 			$loader,
 			[
 				'cache'       => $cacheDir,
-				'auto_reload' => true
+				'auto_reload' => true,
 			]
 		);
 

--- a/cli/Application/Command/Make/Languageflags.php
+++ b/cli/Application/Command/Make/Languageflags.php
@@ -73,7 +73,7 @@ class Languageflags extends Make
 			'	height: ' . $flagHeight . 'px;',
 			'	background:url(flags.png) no-repeat',
 			'}',
-			''
+			'',
 		];
 
 		$colCount = 0;

--- a/cli/Application/Command/Test/Checkstyle.php
+++ b/cli/Application/Command/Test/Checkstyle.php
@@ -45,7 +45,7 @@ class Checkstyle extends Test
 
 		$options['files'] = [
 			JPATH_ROOT . '/cli',
-			JPATH_ROOT . '/src'
+			JPATH_ROOT . '/src',
 		];
 
 		$options['standard'] = [JPATH_ROOT . '/build/phpcs/Joomla'];

--- a/cli/Application/Command/Test/Copypaste.php
+++ b/cli/Application/Command/Test/Copypaste.php
@@ -50,7 +50,7 @@ class Copypaste extends Test
 			new ArrayInput(
 				['values' => [
 					JPATH_ROOT . '/cli',
-					JPATH_ROOT . '/src'
+					JPATH_ROOT . '/src',
 				]]
 			)
 		);

--- a/cli/Application/Command/Test/Langfiles.php
+++ b/cli/Application/Command/Test/Langfiles.php
@@ -115,6 +115,6 @@ class Langfiles extends Test
 			exit($errors ? 1 : 0);
 		}
 
-		return ($errors ? 1 : 0);
+		return $errors ? 1 : 0;
 	}
 }

--- a/cli/Application/Command/Test/Phploc.php
+++ b/cli/Application/Command/Test/Phploc.php
@@ -51,7 +51,7 @@ class Phploc extends Test
 				[
 					'values' => [
 					JPATH_ROOT . '/cli',
-					JPATH_ROOT . '/src'
+					JPATH_ROOT . '/src',
 					],
 				]
 			)

--- a/cli/Application/Command/Test/Phpunit.php
+++ b/cli/Application/Command/Test/Phpunit.php
@@ -43,7 +43,7 @@ class Phpunit extends Test
 		$command = new PHPUnit_TextUI_Command;
 
 		$options = [
-			'--configuration=' . JPATH_ROOT . '/phpunit.xml'
+			'--configuration=' . JPATH_ROOT . '/phpunit.xml',
 		];
 
 		$returnVal = $command->run($options, false);

--- a/cli/Application/Command/TrackerCommand.php
+++ b/cli/Application/Command/TrackerCommand.php
@@ -228,7 +228,7 @@ abstract class TrackerCommand implements LoggerAwareInterface, ContainerAwareInt
 	 */
 	public function displayMissingOption($dir)
 	{
-		$command = strtolower(join('', array_slice(explode('\\', get_class($this)), -1)));
+		$command = strtolower(implode('', array_slice(explode('\\', get_class($this)), -1)));
 
 		$this->getApplication()->outputTitle(sprintf(g11n3t('Command: %s'), ucfirst($command)));
 

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "adaptive/php-text-difference": "1.*"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "~1.11",
         "mustache/mustache": "2.1.*",
         "phpunit/phpunit"  : "4.*",
         "squizlabs/php_codesniffer": "1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bf43a8eb98ac3f10d697c982556f22ef",
-    "content-hash": "1f3c6680cbed95d212d7c2ca870ebb95",
+    "hash": "a89796476d29c2c8c2795981a18fd2da",
+    "content-hash": "0e2e417241d9e4cb8fa1cd79a666f153",
     "packages": [
         {
             "name": "adaptive/php-text-difference",
@@ -2296,6 +2296,64 @@
             "time": "2015-06-14 21:17:01"
         },
         {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v1.11.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "41dc93abd2937a85a3889e28765231d574d2bac8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/41dc93abd2937a85a3889e28765231d574d2bac8",
+                "reference": "41dc93abd2937a85a3889e28765231d574d2bac8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.6",
+                "sebastian/diff": "~1.1",
+                "symfony/console": "~2.3|~3.0",
+                "symfony/event-dispatcher": "~2.1|~3.0",
+                "symfony/filesystem": "~2.1|~3.0",
+                "symfony/finder": "~2.1|~3.0",
+                "symfony/process": "~2.3|~3.0",
+                "symfony/stopwatch": "~2.5|~3.0"
+            },
+            "conflict": {
+                "hhvm": "<3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5|^5",
+                "satooshi/php-coveralls": "^0.7.1"
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\CS\\": "Symfony/CS/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2016-07-22 06:46:28"
+        },
+        {
             "name": "graphp/algorithms",
             "version": "v0.8.1",
             "source": {
@@ -3739,6 +3797,115 @@
             "time": "2016-06-29 07:02:14"
         },
         {
+            "name": "symfony/event-dispatcher",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7f9839ede2070f53e7e2f0849b9bd14748c434c5",
+                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0",
+                "symfony/dependency-injection": "~2.8|~3.0",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/stopwatch": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "322da5f0910d8aa0b25fa65ffccaba68dbddb890"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/322da5f0910d8aa0b25fa65ffccaba68dbddb890",
+                "reference": "322da5f0910d8aa0b25fa65ffccaba68dbddb890",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
+        },
+        {
             "name": "symfony/finder",
             "version": "v3.1.2",
             "source": {
@@ -3784,6 +3951,104 @@
                 }
             ],
             "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "5c11a1a4d4016662eeaf0f8757958c7de069f9a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/5c11a1a4d4016662eeaf0f8757958c7de069f9a0",
+                "reference": "5c11a1a4d4016662eeaf0f8757958c7de069f9a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:42:25"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/bb42806b12c5f89db4ebf64af6741afe6d8457e1",
+                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
             "time": "2016-06-29 05:41:56"
         },

--- a/src/App/Activity/Controller/Ajax/ActivitySnapshot.php
+++ b/src/App/Activity/Controller/Ajax/ActivitySnapshot.php
@@ -56,7 +56,7 @@ class ActivitySnapshot extends AbstractAjaxController
 			3 => g11n3t('Pending'),
 			4 => g11n3t('Ready To Commit'),
 			6 => g11n3t('Needs Review'),
-			7 => g11n3t('Information Required')
+			7 => g11n3t('Information Required'),
 		];
 
 		$iterator = $this->model->getOpenIssues();

--- a/src/App/Activity/Controller/Ajax/TotalActivity.php
+++ b/src/App/Activity/Controller/Ajax/TotalActivity.php
@@ -125,8 +125,8 @@ class TotalActivity extends AbstractAjaxController
 		{
 			$label2->label = sprintf(g11n3t('%1$s Points'), $types[1]);
 			/* $label3->label = sprintf(g11n3t('%1$s Points'), $types[2]); */
-			$data          = [$points[$types[0]], $points[$types[1]], /*$points[$types[2]]*/];
-			$labels        = [$label1, $label2, /*$label3*/];
+			$data          = [$points[$types[0]], $points[$types[1]]/*, $points[$types[2]]*/];
+			$labels        = [$label1, $label2/*, $label3*/];
 		}
 		else
 		{

--- a/src/App/Activity/Model/TotaluseractivityModel.php
+++ b/src/App/Activity/Model/TotaluseractivityModel.php
@@ -54,7 +54,7 @@ class TotaluseractivityModel extends AbstractTrackerDatabaseModel
 		// Select required data.
 		$select = [
 			't.activity_group',
-			'DATE(NOW()) AS end_date'
+			'DATE(NOW()) AS end_date',
 		];
 
 		$periodList  = [1 => 7, 2 => 30, 3 => 90];

--- a/src/App/Activity/Model/UseractivityModel.php
+++ b/src/App/Activity/Model/UseractivityModel.php
@@ -57,7 +57,7 @@ class UseractivityModel extends AbstractTrackerDatabaseModel
 			'SUM(t.activity_points) + (COUNT(c.id) * 5) AS total_points',
 			'SUM(CASE WHEN t.activity_group = ' . $db->quote('Tracker') . ' THEN t.activity_points ELSE 0 END) AS tracker_points',
 			'SUM(CASE WHEN t.activity_group = ' . $db->quote('Test') . ' THEN t.activity_points ELSE 0 END) AS test_points',
-			'(COUNT(c.id) * 5) AS code_points'
+			'(COUNT(c.id) * 5) AS code_points',
 		];
 
 		$query->select($select)

--- a/src/App/Debug/Database/DatabaseDebugger.php
+++ b/src/App/Debug/Database/DatabaseDebugger.php
@@ -33,7 +33,7 @@ class DatabaseDebugger
 	 * @var    array
 	 * @since  1.0
 	 */
-	private $sqlShowProfileEach = array();
+	private $sqlShowProfileEach = [];
 
 	/**
 	 * Array containing EXPLAIN query results
@@ -41,7 +41,7 @@ class DatabaseDebugger
 	 * @var    array
 	 * @since  1.0
 	 */
-	private $explains = array();
+	private $explains = [];
 
 	/**
 	 * Constructor.

--- a/src/App/Debug/Format/Html/SqlFormat.php
+++ b/src/App/Debug/Format/Html/SqlFormat.php
@@ -45,7 +45,7 @@ class SqlFormat
 
 			// Tables are identified by the prefix
 			'/(' . $prefix . '[a-z_0-9]+)/'
-			=> '<span class="dbgTable">$1</span>'
+			=> '<span class="dbgTable">$1</span>',
 		];
 
 		$query = preg_replace(array_keys($regex), array_values($regex), $query);

--- a/src/App/Debug/Format/Html/TableFormat.php
+++ b/src/App/Debug/Format/Html/TableFormat.php
@@ -46,7 +46,7 @@ class TableFormat
 
 			foreach ($tr as $td)
 			{
-				$html .= '<td>' . ($td === null ? 'NULL' : htmlspecialchars($td) ) . '</td>';
+				$html .= '<td>' . ($td === null ? 'NULL' : htmlspecialchars($td)) . '</td>';
 			}
 
 			$html .= '</tr>';
@@ -70,7 +70,7 @@ class TableFormat
 	{
 		$linkFormat = new LinkFormat;
 
-		$html = array();
+		$html = [];
 
 		$html[] = '<table class="table table-hover table-condensed">';
 

--- a/src/App/Debug/TrackerDebugger.php
+++ b/src/App/Debug/TrackerDebugger.php
@@ -139,10 +139,10 @@ class TrackerDebugger implements LoggerAwareInterface, ContainerAwareInterface
 					new StreamHandler(
 						$this->getLogPath('root') . '/error.log',
 						Logger::ERROR
-					)
+					),
 				],
 				[
-					new WebProcessor
+					new WebProcessor,
 				]
 			)
 		);

--- a/src/App/GitHub/Controller/Ajax/Hooks/Add.php
+++ b/src/App/GitHub/Controller/Ajax/Hooks/Add.php
@@ -39,10 +39,10 @@ class Add extends AbstractAjaxController
 		$name   = 'web';
 		$active = 1;
 
-		$config = array(
+		$config = [
 			'url'          => $url,
-			'content-type' => 'json'
-		);
+			'content-type' => 'json',
+		];
 
 		// Create the hook.
 		$gitHub->repositories->hooks->create(

--- a/src/App/GitHub/Controller/Ajax/Hooks/Modify.php
+++ b/src/App/GitHub/Controller/Ajax/Hooks/Modify.php
@@ -109,8 +109,8 @@ class Modify extends AbstractAjaxController
 			$hook->name,
 			$hook->config,
 			$hook->events,
-			array(),
-			array(),
+			[],
+			[],
 			$hook->active
 		);
 

--- a/src/App/Groups/Controller/Group/Save.php
+++ b/src/App/Groups/Controller/Group/Save.php
@@ -73,7 +73,7 @@ class Save extends AbstractTrackerController
 	 */
 	public function execute()
 	{
-		$group = $this->getContainer()->get('app')->input->get('group', array(), 'array');
+		$group = $this->getContainer()->get('app')->input->get('group', [], 'array');
 
 		$table = new GroupsTable($this->getContainer()->get('db'));
 

--- a/src/App/Groups/Table/GroupsTable.php
+++ b/src/App/Groups/Table/GroupsTable.php
@@ -56,7 +56,7 @@ class GroupsTable extends AbstractDatabaseTable
 	 * @since   1.0
 	 * @throws  \UnexpectedValueException
 	 */
-	public function bind($source, $ignore = array())
+	public function bind($source, $ignore = [])
 	{
 		if (false === is_array($source))
 		{

--- a/src/App/Projects/Controller/Project/Save.php
+++ b/src/App/Projects/Controller/Project/Save.php
@@ -70,7 +70,7 @@ class Save extends AbstractTrackerController
 
 		$table = new ProjectsTable($this->getContainer()->get('db'));
 
-		$table->save($app->input->get('project', array(), 'array'));
+		$table->save($app->input->get('project', [], 'array'));
 
 		// Reload the project.
 		$app->getProject(true);

--- a/src/App/Projects/Model/ProjectsModel.php
+++ b/src/App/Projects/Model/ProjectsModel.php
@@ -76,7 +76,7 @@ class ProjectsModel extends AbstractTrackerListModel
 		$query = $db->getQuery(true);
 
 		$query->select('DISTINCT ' . $db->quoteName('p.project_id'));
-		$query->select($db->quoteName(array('p.title', 'p.alias', 'p.gh_user', 'p.gh_project')));
+		$query->select($db->quoteName(['p.title', 'p.alias', 'p.gh_user', 'p.gh_project']));
 
 		$query->from($db->quoteName('#__tracker_projects', 'p'));
 

--- a/src/App/Projects/Table/ProjectsTable.php
+++ b/src/App/Projects/Table/ProjectsTable.php
@@ -130,7 +130,7 @@ class ProjectsTable extends AbstractDatabaseTable
 
 			if ($newId)
 			{
-				$data = array();
+				$data = [];
 				$data['project_id'] = $newId;
 				$data['title']      = 'Public';
 				$data['can_view']   = 1;

--- a/src/App/Projects/TrackerProject.php
+++ b/src/App/Projects/TrackerProject.php
@@ -108,7 +108,7 @@ class TrackerProject implements \Serializable
 	 * @var    array
 	 * @since  1.0
 	 */
-	protected $accessMap = array();
+	protected $accessMap = [];
 
 	/**
 	 * Array containing default actions
@@ -116,7 +116,7 @@ class TrackerProject implements \Serializable
 	 * @var    array
 	 * @since  1.0
 	 */
-	private $defaultActions = array('view', 'create', 'edit', 'editown', 'manage');
+	private $defaultActions = ['view', 'create', 'edit', 'editown', 'manage'];
 
 	/**
 	 * Array containing default user groups
@@ -124,7 +124,7 @@ class TrackerProject implements \Serializable
 	 * @var    array
 	 * @since  1.0
 	 */
-	private $defaultGroups = array('Public', 'User');
+	private $defaultGroups = ['Public', 'User'];
 
 	/**
 	 * @var    DatabaseDriver
@@ -234,7 +234,7 @@ class TrackerProject implements \Serializable
 	{
 		$db = $this->database;
 
-		$map = array();
+		$map = [];
 
 		foreach ($this->defaultGroups as $group)
 		{
@@ -243,7 +243,7 @@ class TrackerProject implements \Serializable
 
 		foreach ($this->defaultActions as $action)
 		{
-			$map['Custom'][$action] = array();
+			$map['Custom'][$action] = [];
 
 			foreach ($this->defaultGroups as $group)
 			{
@@ -251,7 +251,7 @@ class TrackerProject implements \Serializable
 			}
 		}
 
-		$groups = array();
+		$groups = [];
 
 		if ($this->project_id)
 		{
@@ -311,7 +311,7 @@ class TrackerProject implements \Serializable
 	 */
 	public function getLabels()
 	{
-		static $labels = array();
+		static $labels = [];
 
 		if (!$labels)
 		{
@@ -322,7 +322,7 @@ class TrackerProject implements \Serializable
 			$labelList = $db ->setQuery(
 				$db->getQuery(true)
 					->from($db->quoteName($table->getTableName()))
-					->select(array('label_id', 'name', 'color'))
+					->select(['label_id', 'name', 'color'])
 					->where($db->quoteName('project_id') . ' = ' . $this->project_id)
 			)->loadObjectList();
 
@@ -360,7 +360,7 @@ class TrackerProject implements \Serializable
 			$milestones = $db ->setQuery(
 				$db->getQuery(true)
 					->from($db->quoteName($table->getTableName()))
-					->select(array('milestone_id', 'milestone_number', 'title', 'description', 'state', 'due_on'))
+					->select(['milestone_id', 'milestone_number', 'title', 'description', 'state', 'due_on'])
 					->where($db->quoteName('project_id') . ' = ' . $this->project_id)
 					->order($db->quoteName('title'))
 			)->loadObjectList();
@@ -482,11 +482,11 @@ class TrackerProject implements \Serializable
 	 */
 	public function serialize()
 	{
-		$props = array();
+		$props = [];
 
 		foreach (get_object_vars($this) as $key => $value)
 		{
-			if (in_array($key, array('authModel', 'cleared', 'authId', 'database')))
+			if (in_array($key, ['authModel', 'cleared', 'authId', 'database']))
 			{
 				continue;
 			}

--- a/src/App/Support/Controller/Filetree.php
+++ b/src/App/Support/Controller/Filetree.php
@@ -63,7 +63,7 @@ class Filetree extends AbstractTrackerController
 			// All files
 			foreach ($files as $file)
 			{
-				if (!is_dir($path . '/' . $file) )
+				if (!is_dir($path . '/' . $file))
 				{
 					// Dumb spoof check
 					$file = str_replace('..', '', $file);

--- a/src/App/System/Controller/Config/Save.php
+++ b/src/App/System/Controller/Config/Save.php
@@ -33,7 +33,7 @@ class Save extends AbstractTrackerController
 
 		$application->getUser()->authorize('admin');
 
-		$config = $this->cleanArray($application->input->get('config', array(), 'array'));
+		$config = $this->cleanArray($application->input->get('config', [], 'array'));
 
 		if (!$config)
 		{

--- a/src/App/Tracker/Controller/AbstractHookController.php
+++ b/src/App/Tracker/Controller/AbstractHookController.php
@@ -179,7 +179,7 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 				[
 					new StreamHandler(
 						$this->getContainer()->get('app')->get('debug.log-path') . '/github_' . strtolower($this->type) . '.log'
-					)
+					),
 				]
 			)
 		);
@@ -389,7 +389,7 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 			return '';
 		}
 
-		$appLabelIds = array();
+		$appLabelIds = [];
 
 		// Make sure the label is present in the database by pulling the ID, add it if it isn't
 		$query = $this->db->getQuery(true);
@@ -410,7 +410,7 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 			{
 				$table = new LabelsTable($this->db);
 
-				$data = array();
+				$data = [];
 				$data['project_id'] = $this->project->project_id;
 				$data['name']       = $label->name;
 				$data['color']      = $label->color;
@@ -496,7 +496,7 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 				return $status;
 
 			default :
-				return null;
+				return;
 		}
 	}
 

--- a/src/App/Tracker/Controller/Category/Save.php
+++ b/src/App/Tracker/Controller/Category/Save.php
@@ -53,7 +53,7 @@ class Save extends AbstractTrackerController
 		try
 		{
 			$this->model->setProject($project);
-			$data = $app->input->get('category', array(), 'array');
+			$data = $app->input->get('category', [], 'array');
 
 			if (isset($data['id']))
 			{

--- a/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/AbstractListener.php
@@ -214,7 +214,7 @@ abstract class AbstractListener implements ContainerAwareInterface
 			return $hookData->issue->number;
 		}
 
-		return null;
+		return;
 	}
 
 	/**
@@ -453,7 +453,6 @@ abstract class AbstractListener implements ContainerAwareInterface
 	 * @return  string  The currently configured bot account
 	 *
 	 * @since   1.0
-	 *
 	 */
 	protected function getGithubBotName($project)
 	{

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -228,7 +228,7 @@ class JoomlacmsPullsListener extends AbstractListener
 					$data = [
 						'status'      => 10,
 						'closed_date' => (new Date)->format('Y-m-d H:i:s'),
-						'closed_by'   => 'jissues-bot'
+						'closed_by'   => 'jissues-bot',
 					];
 
 					$table->save($data);

--- a/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
@@ -164,7 +164,7 @@ class ReceiveCommentsHook extends AbstractHookController
 		// Prepare the dates for insertion to the database
 		$dateFormat = $this->db->getDateFormat();
 
-		$data = array();
+		$data = [];
 		$data['issue_number']    = $this->hookData->issue->number;
 		$data['title']           = $this->hookData->issue->title;
 		$data['description']     = $this->parseText($this->hookData->issue->body);

--- a/src/App/Tracker/Controller/Hooks/ReceiveIssuesHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveIssuesHook.php
@@ -87,7 +87,7 @@ class ReceiveIssuesHook extends AbstractHookController
 		$opened   = new Date($this->hookData->issue->created_at);
 		$modified = new Date($this->hookData->issue->updated_at);
 
-		$data = array();
+		$data = [];
 		$data['issue_number']    = $this->hookData->issue->number;
 		$data['title']           = $this->hookData->issue->title;
 		$data['description']     = $parsedText;
@@ -205,10 +205,10 @@ class ReceiveIssuesHook extends AbstractHookController
 		try
 		{
 			$table->load(
-				array(
+				[
 					'issue_number' => $this->hookData->issue->number,
-					'project_id' => $this->project->project_id
-				)
+					'project_id' => $this->project->project_id,
+				]
 			);
 		}
 		catch (\Exception $e)

--- a/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
@@ -107,7 +107,7 @@ class ReceivePullsHook extends AbstractHookController
 		$opened     = new Date($this->data->created_at);
 		$modified   = new Date($this->data->updated_at);
 
-		$data = array();
+		$data = [];
 		$data['issue_number']    = $this->data->number;
 		$data['title']           = $this->data->title;
 		$data['description']     = $this->parseText($this->data->body);
@@ -252,10 +252,10 @@ class ReceivePullsHook extends AbstractHookController
 		try
 		{
 			$table->load(
-				array(
+				[
 					'issue_number' => $this->data->number,
-					'project_id' => $this->project->project_id
-				)
+					'project_id' => $this->project->project_id,
+				]
 			);
 		}
 		catch (\Exception $e)

--- a/src/App/Tracker/Controller/Issue/Ajax/Listing.php
+++ b/src/App/Tracker/Controller/Issue/Ajax/Listing.php
@@ -203,7 +203,7 @@ class Listing extends AbstractAjaxController
 		}
 
 		// Prepare the response.
-		$items                = array('items' => $listItems, 'pagesTotal' => $pagesTotal, 'currentPage' => $currentPage);
+		$items                = ['items' => $listItems, 'pagesTotal' => $pagesTotal, 'currentPage' => $currentPage];
 		$this->response->data = (object) $items;
 	}
 }

--- a/src/App/Tracker/Controller/Issue/Edit.php
+++ b/src/App/Tracker/Controller/Issue/Edit.php
@@ -89,7 +89,7 @@ class Edit extends AbstractTrackerController
 
 		$item->userTest = $this->model->getUserTest($item->id, $user->username, $sha);
 
-		$item->categoryids = array();
+		$item->categoryids = [];
 
 		foreach ($item->categories as $category)
 		{

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -42,7 +42,7 @@ class Save extends AbstractTrackerController
 		/* @type \JTracker\Application $application */
 		$application = $this->getContainer()->get('app');
 
-		$src = $application->input->get('item', array(), 'array');
+		$src = $application->input->get('item', [], 'array');
 
 		$user = $application->getUser();
 		$project = $application->getProject();
@@ -59,7 +59,7 @@ class Save extends AbstractTrackerController
 
 		$item = $model->getItem($issueNumber);
 
-		$data = array();
+		$data = [];
 
 		if ($user->check('edit'))
 		{

--- a/src/App/Tracker/Controller/Issue/Submit.php
+++ b/src/App/Tracker/Controller/Issue/Submit.php
@@ -54,7 +54,7 @@ class Submit extends AbstractTrackerController
 		}
 
 		// Prepare issue for the store
-		$data = array();
+		$data = [];
 
 		$data['title']        = $application->input->getString('title');
 		$data['milestone_id'] = $application->input->getInt('milestone_id');

--- a/src/App/Tracker/Controller/Upload/Ajax/Put.php
+++ b/src/App/Tracker/Controller/Upload/Ajax/Put.php
@@ -60,7 +60,7 @@ class Put extends AbstractAjaxController
 					'deleteUrl'    => '/upload/delete/?file=' . $destName,
 					'deleteType'   => 'POST',
 					'editorId'     => $application->input->get('editorId'),
-				]
+				],
 			];
 
 			// Do not pass the thumbnail if not an image
@@ -87,8 +87,8 @@ class Put extends AbstractAjaxController
 
 				$data = [
 					[
-						'error' => $errors
-					]
+						'error' => $errors,
+					],
 				];
 			}
 

--- a/src/App/Tracker/Exception/ValidationException.php
+++ b/src/App/Tracker/Exception/ValidationException.php
@@ -21,7 +21,7 @@ class ValidationException extends \Exception
 	 * @var    array|string
 	 * @since  1.0
 	 */
-	protected $errors = array();
+	protected $errors = [];
 
 	/**
 	 * Constructor.

--- a/src/App/Tracker/Model/ActivityModel.php
+++ b/src/App/Tracker/Model/ActivityModel.php
@@ -46,7 +46,7 @@ class ActivityModel extends AbstractTrackerDatabaseModel
 			'issue_number' => (int) $itemNumber,
 			'gh_comment_id' => (int) $commentId,
 			'text' => $text,
-			'text_raw' => $textRaw
+			'text_raw' => $textRaw,
 			]
 		);
 	}

--- a/src/App/Tracker/Model/CategoriesModel.php
+++ b/src/App/Tracker/Model/CategoriesModel.php
@@ -12,7 +12,6 @@ use Joomla\Database\DatabaseQuery;
 
 use JTracker\Model\AbstractTrackerListModel;
 
-
 /**
  * Model to get data for the categories list view
  *

--- a/src/App/Tracker/Model/CategoryModel.php
+++ b/src/App/Tracker/Model/CategoryModel.php
@@ -37,7 +37,7 @@ class CategoryModel extends AbstractTrackerDatabaseModel
 	 */
 	public function add(array $src)
 	{
-		$data = array();
+		$data = [];
 
 		$filter              = new InputFilter;
 		$data['title']       = $filter->clean($src['title'], 'string');
@@ -104,7 +104,7 @@ class CategoryModel extends AbstractTrackerDatabaseModel
 		$db     = $this->getDb();
 		$filter = new InputFilter;
 
-		$data = array();
+		$data = [];
 		$data['id']          = $filter->clean($src['id'], 'uint');
 		$data['title']       = $filter->clean($src['title'], 'string');
 		$data['alias']       = $filter->clean($src['alias'], 'cmd');
@@ -224,7 +224,7 @@ class CategoryModel extends AbstractTrackerDatabaseModel
 	 */
 	public function saveCategory(array $src)
 	{
-		$data       = array();
+		$data       = [];
 		$issue_id   = (int) $src['issue_id'];
 
 		if ($src['categories'])
@@ -279,10 +279,10 @@ class CategoryModel extends AbstractTrackerDatabaseModel
 	 */
 	public function updateCategory(array $src)
 	{
-		$newCategories    = ($src['categories']) ? $src['categories'] : array();
+		$newCategories    = ($src['categories']) ? $src['categories'] : [];
 		$oldSrc           = $this->getCategories($src['issue_id']);
-		$oldCategories    = array();
-		$data             = array();
+		$oldCategories    = [];
+		$data             = [];
 		$data['issue_id'] = (int) $src['issue_id'];
 
 		foreach ($oldSrc as $category)
@@ -310,7 +310,7 @@ class CategoryModel extends AbstractTrackerDatabaseModel
 
 		if ($insert || $delete)
 		{
-			$changes                 = array();
+			$changes                 = [];
 			$changes['modified_by']  = $src['modified_by'];
 			$changes['issue_number'] = $src['issue_number'];
 			$changes['project_id']   = $src['project_id'];
@@ -375,8 +375,8 @@ class CategoryModel extends AbstractTrackerDatabaseModel
 
 		$change       = new \stdClass;
 		$change->name = 'category';
-		$change->old  = array();
-		$change->new  = array();
+		$change->old  = [];
+		$change->new  = [];
 
 		foreach ($src['old'] as $key => $old)
 		{
@@ -392,13 +392,13 @@ class CategoryModel extends AbstractTrackerDatabaseModel
 			$change->new[$key]['color'] = $newCategory->color;
 		}
 
-		$data                 = array();
+		$data                 = [];
 		$data['event']        = 'change';
 		$data['created_date'] = $date;
 		$data['user']         = $src['modified_by'];
 		$data['issue_number'] = (int) $src['issue_number'];
 		$data['project_id']   = (int) $src['project_id'];
-		$data['text']         = json_encode(array($change));
+		$data['text']         = json_encode([$change]);
 
 		$table = new ActivitiesTable($this->getDb());
 		$table->save($data);

--- a/src/App/Tracker/Model/IssueModel.php
+++ b/src/App/Tracker/Model/IssueModel.php
@@ -132,7 +132,7 @@ class IssueModel extends AbstractTrackerDatabaseModel
 
 					$activities[] = $a;
 
-					unset ($commits[$i1]);
+					unset($commits[$i1]);
 				}
 			}
 
@@ -157,7 +157,7 @@ class IssueModel extends AbstractTrackerDatabaseModel
 		// Group relations by type
 		if ($item->relations_f)
 		{
-			$arr = array();
+			$arr = [];
 
 			foreach ($item->relations_f as $relation)
 			{
@@ -344,7 +344,7 @@ class IssueModel extends AbstractTrackerDatabaseModel
 	{
 		if (!$sha)
 		{
-			return null;
+			return;
 		}
 
 		return $this->db->setQuery(
@@ -472,7 +472,7 @@ class IssueModel extends AbstractTrackerDatabaseModel
 	{
 		$filter = new InputFilter;
 
-		$data = array();
+		$data = [];
 
 		$data['id']              = $filter->clean($src['id'], 'int');
 		$data['status']          = $filter->clean($src['status'], 'int');
@@ -574,12 +574,12 @@ class IssueModel extends AbstractTrackerDatabaseModel
 		// Insert a new record if one doesn't exist
 		if (!$voteId)
 		{
-			$columnsArray = array(
+			$columnsArray = [
 				$db->quoteName('issue_number'),
 				$db->quoteName('user_id'),
 				$db->quoteName('experienced'),
 				$db->quoteName('score'),
-			);
+			];
 
 			$query->clear()
 				->insert($db->quoteName('#__issues_voting'))

--- a/src/App/Tracker/Model/IssuesModel.php
+++ b/src/App/Tracker/Model/IssuesModel.php
@@ -363,7 +363,7 @@ class IssuesModel extends AbstractTrackerListModel
 
 			if ($issues != null)
 			{
-				$issueId = array();
+				$issueId = [];
 
 				foreach ($issues as $issue)
 				{

--- a/src/App/Tracker/Table/ActivitiesTable.php
+++ b/src/App/Tracker/Table/ActivitiesTable.php
@@ -53,7 +53,7 @@ class ActivitiesTable extends AbstractDatabaseTable
 	 */
 	public function check()
 	{
-		$errors = array();
+		$errors = [];
 
 		if (trim($this->user) == '')
 		{

--- a/src/App/Tracker/Table/CategoryTable.php
+++ b/src/App/Tracker/Table/CategoryTable.php
@@ -47,7 +47,7 @@ class CategoryTable extends AbstractDatabaseTable
 	 */
 	public function check()
 	{
-		$errors = array();
+		$errors = [];
 
 		if (trim($this->title) == '')
 		{

--- a/src/App/Tracker/Table/IssueCategoryMappingTable.php
+++ b/src/App/Tracker/Table/IssueCategoryMappingTable.php
@@ -45,7 +45,7 @@ class IssueCategoryMappingTable extends AbstractDatabaseTable
 	 */
 	public function check()
 	{
-		$errors = array();
+		$errors = [];
 
 		if (trim($this->issue_id) == '')
 		{

--- a/src/App/Tracker/Table/IssuesTable.php
+++ b/src/App/Tracker/Table/IssuesTable.php
@@ -85,11 +85,11 @@ class IssuesTable extends AbstractDatabaseTable
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public function bind($src, $ignore = array())
+	public function bind($src, $ignore = [])
 	{
 		if ($this->id)
 		{
-			$oldValues = array();
+			$oldValues = [];
 
 			foreach ($this as $k => $v)
 			{
@@ -126,7 +126,7 @@ class IssuesTable extends AbstractDatabaseTable
 	 */
 	public function check()
 	{
-		$errors = array();
+		$errors = [];
 
 		$this->title = trim($this->title);
 
@@ -224,7 +224,7 @@ class IssuesTable extends AbstractDatabaseTable
 		// Add a record to the activity table if a new item
 		if ($isNew)
 		{
-			$data = array();
+			$data = [];
 			$data['event']        = 'open';
 			$data['created_date'] = $this->opened_date;
 			$data['user']         = $this->opened_by;
@@ -253,7 +253,7 @@ class IssuesTable extends AbstractDatabaseTable
 	 */
 	private function processChanges()
 	{
-		$changes = array();
+		$changes = [];
 
 		foreach ($this as $fName => $field)
 		{
@@ -295,7 +295,7 @@ class IssuesTable extends AbstractDatabaseTable
 
 		if ($changes)
 		{
-			$data = array();
+			$data = [];
 			$data['event']        = 'change';
 			$data['created_date'] = $this->modified_date;
 			$data['user']         = $this->modified_by;

--- a/src/App/Tracker/View/Issues/IssuesHtmlView.php
+++ b/src/App/Tracker/View/Issues/IssuesHtmlView.php
@@ -41,7 +41,7 @@ class IssuesHtmlView extends AbstractTrackerHtmlView
 		$this->setData(
 			[
 				'state'   => $this->model->getState(),
-				'project' => $this->getProject()
+				'project' => $this->getProject(),
 			]
 		);
 

--- a/src/App/Users/Controller/Ajax/Assign.php
+++ b/src/App/Users/Controller/Ajax/Assign.php
@@ -100,10 +100,10 @@ class Assign extends AbstractAjaxController
 	{
 		$db = $this->getContainer()->get('db');
 
-		$data = array(
+		$data = [
 			$db->quoteName('user_id')  => (int) $userId,
-			$db->quoteName('group_id') => (int) $groupId
-		);
+			$db->quoteName('group_id') => (int) $groupId,
+		];
 
 		$db->setQuery(
 			$db->getQuery(true)

--- a/src/App/Users/Controller/Ajax/Search.php
+++ b/src/App/Users/Controller/Ajax/Search.php
@@ -69,7 +69,7 @@ class Search extends AbstractAjaxController
 			$users = $db->setQuery($query, 0, 10)
 				->loadColumn();
 
-			$this->response->data->options = $users ? : array();
+			$this->response->data->options = $users ? : [];
 		}
 	}
 }

--- a/src/App/Users/Controller/Login.php
+++ b/src/App/Users/Controller/Login.php
@@ -71,7 +71,7 @@ class Login extends AbstractTrackerController
 				'tokenurl'     => 'https://github.com/login/oauth/access_token',
 				'redirect_uri' => $app->get('uri.request'),
 				'clientid'     => $app->get('github.client_id'),
-				'clientsecret' => $app->get('github.client_secret')
+				'clientsecret' => $app->get('github.client_secret'),
 			]
 		);
 

--- a/src/App/Users/Controller/User/Save.php
+++ b/src/App/Users/Controller/User/Save.php
@@ -32,7 +32,7 @@ class Save extends AbstractTrackerController
 		/* @type \JTracker\Application $application */
 		$application = $this->getContainer()->get('app');
 
-		$src = $application->input->get('item', array(), 'array');
+		$src = $application->input->get('item', [], 'array');
 
 		if (!$src['id'])
 		{

--- a/src/App/Users/Model/UserModel.php
+++ b/src/App/Users/Model/UserModel.php
@@ -60,7 +60,7 @@ class UserModel extends AbstractTrackerDatabaseModel
 	{
 		$filter = new InputFilter;
 
-		$data = array();
+		$data = [];
 
 		$data['id'] = $filter->clean($src['id'], 'int');
 

--- a/src/App/Users/Model/UsersModel.php
+++ b/src/App/Users/Model/UsersModel.php
@@ -32,7 +32,7 @@ class UsersModel extends AbstractTrackerListModel
 		$db    = $this->getDb();
 		$query = $db->getQuery(true);
 
-		$query->select(array('id', 'username'));
+		$query->select(['id', 'username']);
 		$query->from('#__users');
 
 		$filter = $this->state->get('filter.search-user');

--- a/src/JTracker/Application.php
+++ b/src/JTracker/Application.php
@@ -570,7 +570,7 @@ final class Application extends AbstractWebApplication implements ContainerAware
 			return $registry->set($key, $value);
 		}
 
-		return null;
+		return;
 	}
 
 	/**

--- a/src/JTracker/Authentication/GitHub/GitHubUser.php
+++ b/src/JTracker/Authentication/GitHub/GitHubUser.php
@@ -52,7 +52,7 @@ class GitHubUser extends User
 
 		foreach ($data as $k => $v)
 		{
-			if (property_exists($this, $k) && false == in_array($k, array('id')))
+			if (property_exists($this, $k) && false == in_array($k, ['id']))
 			{
 				$this->$k = $v;
 			}

--- a/src/JTracker/Authentication/User.php
+++ b/src/JTracker/Authentication/User.php
@@ -89,7 +89,7 @@ abstract class User implements \Serializable
 	 * @var    array
 	 * @since  1.0
 	 */
-	protected $accessGroups = array();
+	protected $accessGroups = [];
 
 	/**
 	 * A list of cleared access rights.
@@ -97,7 +97,7 @@ abstract class User implements \Serializable
 	 * @var    array
 	 * @since  1.0
 	 */
-	private $cleared = array();
+	private $cleared = [];
 
 	/**
 	 * Database object
@@ -260,7 +260,7 @@ abstract class User implements \Serializable
 	 */
 	public function canEditOwn($username)
 	{
-		return ($this->check('editown') && $this->username == $username);
+		return $this->check('editown') && $this->username == $username;
 	}
 
 	/**
@@ -385,7 +385,7 @@ abstract class User implements \Serializable
 			[
 				$this->id,
 				$this->username,
-				$this->project
+				$this->project,
 			]
 		);
 	}
@@ -401,7 +401,7 @@ abstract class User implements \Serializable
 	 */
 	public function unserialize($serialized)
 	{
-		list ($this->id, $this->username, $this->project) = unserialize($serialized);
+		list($this->id, $this->username, $this->project) = unserialize($serialized);
 
 		// Initialize the user parameters object.
 		$this->params = new Registry;

--- a/src/JTracker/Database/AbstractDatabaseTable.php
+++ b/src/JTracker/Database/AbstractDatabaseTable.php
@@ -32,7 +32,7 @@ class AbstractDatabaseTable implements \IteratorAggregate
 	 * @var    array
 	 * @since  1.0
 	 */
-	protected $tableKeys = array();
+	protected $tableKeys = [];
 
 	/**
 	 * Indicates that the primary keys autoincrement.
@@ -80,7 +80,7 @@ class AbstractDatabaseTable implements \IteratorAggregate
 		// Set the key to be an array.
 		if (is_string($keys))
 		{
-			$keys = array($keys);
+			$keys = [$keys];
 		}
 		elseif (is_object($keys))
 		{
@@ -189,7 +189,7 @@ class AbstractDatabaseTable implements \IteratorAggregate
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public function bind($src, $ignore = array())
+	public function bind($src, $ignore = [])
 	{
 		// If the source value is not an array or object return false.
 		if (!is_object($src) && !is_array($src))
@@ -242,7 +242,7 @@ class AbstractDatabaseTable implements \IteratorAggregate
 		if (empty($keys))
 		{
 			$empty = true;
-			$keys  = array();
+			$keys  = [];
 
 			// If empty, use the value of the current key
 			foreach ($this->tableKeys as $key)
@@ -269,7 +269,7 @@ class AbstractDatabaseTable implements \IteratorAggregate
 					throw new \InvalidArgumentException('Table has multiple primary keys specified, only one primary key value provided.');
 				}
 
-				$keys = array($this->getKeyName() => $keys);
+				$keys = [$this->getKeyName() => $keys];
 			}
 			else
 			{
@@ -478,12 +478,12 @@ class AbstractDatabaseTable implements \IteratorAggregate
 		{
 			if (is_string($pk))
 			{
-				$pk = array($this->tableKeys[0] => $pk);
+				$pk = [$this->tableKeys[0] => $pk];
 			}
 
 			$pk = (object) $pk;
 
-			foreach ($this->tableKeys AS $k)
+			foreach ($this->tableKeys as $k)
 			{
 				$query->where($this->db->quoteName($k) . ' = ' . $this->db->quote($pk->$k));
 			}

--- a/src/JTracker/Database/Migrations.php
+++ b/src/JTracker/Database/Migrations.php
@@ -106,7 +106,7 @@ class Migrations
 			[
 				'missingMigrations' => $countMissing,
 				'currentVersion'    => $currentVersion,
-				'latestVersion'     => $latestVersion
+				'latestVersion'     => $latestVersion,
 			]
 		);
 	}

--- a/src/JTracker/Github/GithubFactory.php
+++ b/src/JTracker/Github/GithubFactory.php
@@ -122,10 +122,10 @@ abstract class GithubFactory
 						new StreamHandler(
 							$app->get('debug.log-path', JPATH_ROOT) . '/github.log',
 							Logger::DEBUG
-						)
+						),
 					],
 					[
-						new WebProcessor
+						new WebProcessor,
 					]
 				)
 			);

--- a/src/JTracker/Github/Package/Issues.php
+++ b/src/JTracker/Github/Package/Issues.php
@@ -46,7 +46,7 @@ class Issues extends Package
 	 * @since   1.0
 	 * @throws  \DomainException
 	 */
-	public function create($user, $repo, $title, $body = null, $assignee = null, $milestone = null, array $labels = array())
+	public function create($user, $repo, $title, $body = null, $assignee = null, $milestone = null, array $labels = [])
 	{
 		// Build the request path.
 		$path = '/repos/' . $user . '/' . $repo . '/issues';
@@ -59,13 +59,13 @@ class Issues extends Package
 
 		// Build the request data.
 		$data = json_encode(
-			array(
+			[
 				'title'     => $title,
 				'assignee'  => $assignee,
 				'milestone' => $milestone,
 				'labels'    => $labels,
-				'body'      => $body
-			)
+				'body'      => $body,
+			]
 		);
 
 		// Send the request.

--- a/src/JTracker/Github/Package/Issues/Comments.php
+++ b/src/JTracker/Github/Package/Issues/Comments.php
@@ -139,9 +139,9 @@ class Comments extends Package
 
 		// Build the request data.
 		$data = json_encode(
-			array(
-				'body' => $body
-			)
+			[
+				'body' => $body,
+			]
 		);
 
 		// Send the request.
@@ -170,9 +170,9 @@ class Comments extends Package
 
 		// Build the request data.
 		$data = json_encode(
-			array(
+			[
 				'body' => $body,
-			)
+			]
 		);
 
 		// Send the request.

--- a/src/JTracker/Github/Package/Markdown.php
+++ b/src/JTracker/Github/Package/Markdown.php
@@ -37,7 +37,7 @@ class Markdown extends Package
 	public function render($text, $mode = 'gfm', $context = null)
 	{
 		// The valid modes
-		$validModes = array('gfm', 'markdown');
+		$validModes = ['gfm', 'markdown'];
 
 		// Make sure the scope is valid
 		if (!in_array($mode, $validModes))
@@ -55,11 +55,11 @@ class Markdown extends Package
 
 		// Build the request data.
 		$data = str_replace('\\/', '/', json_encode(
-				array(
+				[
 					'text'    => $text,
 					'mode'    => $mode,
-					'context' => $context
-				)
+					'context' => $context,
+				]
 			)
 		);
 

--- a/src/JTracker/Github/Package/Repositories.php
+++ b/src/JTracker/Github/Package/Repositories.php
@@ -202,7 +202,7 @@ class Repositories extends Package
 			// Create a repository for a user
 			: '/user/repos';
 
-		$data = array(
+		$data = [
 			'name'               => $name,
 			'description'        => $description,
 			'homepage'           => $homepage,
@@ -212,8 +212,8 @@ class Repositories extends Package
 			'has_downloads'      => $has_downloads,
 			'team_id'            => $team_id,
 			'auto_init'          => $auto_init,
-			'gitignore_template' => $gitignore_template
-		);
+			'gitignore_template' => $gitignore_template,
+		];
 
 		// Send the request.
 		return $this->processResponse(
@@ -267,7 +267,7 @@ class Repositories extends Package
 	{
 		$path = '/repos/' . $owner . '/' . $repo;
 
-		$data = array(
+		$data = [
 			'name'           => $name,
 			'description'    => $description,
 			'homepage'       => $homepage,
@@ -275,8 +275,8 @@ class Repositories extends Package
 			'has_issues'     => $has_issues,
 			'has_wiki'       => $has_wiki,
 			'has_downloads'  => $has_downloads,
-			'default_branch' => $default_branch
-		);
+			'default_branch' => $default_branch,
+		];
 
 		// Send the request.
 		return $this->processResponse(

--- a/src/JTracker/Github/Package/Repositories/Statuses.php
+++ b/src/JTracker/Github/Package/Repositories/Statuses.php
@@ -38,22 +38,21 @@ class Statuses extends Package
 	 * @return object
 	 *
 	 * @since   1.0
-	 *
 	 */
 	public function create($user, $repo, $sha, $state, $targetUrl = null, $description = null, $context = null)
 	{
 		// Build the request path.
 		$path = '/repos/' . $user . '/' . $repo . '/statuses/' . $sha;
 
-		if (!in_array($state, array('pending', 'success', 'error', 'failure')))
+		if (!in_array($state, ['pending', 'success', 'error', 'failure']))
 		{
 			throw new \InvalidArgumentException('State must be one of pending, success, error or failure.');
 		}
 
 		// Build the request data.
-		$data = array(
-			'state' => $state
-		);
+		$data = [
+			'state' => $state,
+		];
 
 		if (!is_null($targetUrl))
 		{

--- a/src/JTracker/Helper/IpHelper.php
+++ b/src/JTracker/Helper/IpHelper.php
@@ -21,7 +21,7 @@ abstract class IpHelper
 	 * @var    array
 	 * @since  1.0
 	 */
-	protected static $cidrRanges = array(
+	protected static $cidrRanges = [
 		0  => 4294967296,
 		1  => 2147483648,
 		2  => 1073741824,
@@ -54,8 +54,8 @@ abstract class IpHelper
 		29 => 8,
 		30 => 4,
 		31 => 2,
-		32 => 1
-	);
+		32 => 1,
+	];
 
 	/**
 	 * Array containing the authorized lookup types for ipInRange()
@@ -63,7 +63,7 @@ abstract class IpHelper
 	 * @var    array
 	 * @since  1.0
 	 */
-	protected static $authorizedTypes = array('cidr', 'range');
+	protected static $authorizedTypes = ['cidr', 'range'];
 
 	/**
 	 * Determines if the supplied IP address is in the valid IP range
@@ -116,7 +116,7 @@ abstract class IpHelper
 		{
 			case 'cidr':
 				// Split the CIDR address into a separate IP address and bits
-				list ($subnet, $bits) = explode('/', $valid);
+				list($subnet, $bits) = explode('/', $valid);
 
 				// Convert the network address into number format and calculate the end value
 				$start = ip2long($subnet);
@@ -141,6 +141,6 @@ abstract class IpHelper
 				);
 		}
 
-		return array('start' => $start, 'end' => $end);
+		return ['start' => $start, 'end' => $end];
 	}
 }

--- a/src/JTracker/Helper/LanguageHelper.php
+++ b/src/JTracker/Helper/LanguageHelper.php
@@ -34,7 +34,7 @@ abstract class LanguageHelper
 		'nl-BE' => 'nl-BE',
 		'pt-BR' => 'pt-BR',
 		'pt-PT' => 'pt-PT',
-		'zh-CN' => 'zh-CN'
+		'zh-CN' => 'zh-CN',
 	];
 
 	/**
@@ -46,118 +46,118 @@ abstract class LanguageHelper
 		'ca-ES' => [
 			'iso' => 'cat',
 			'name' => 'Catalan',
-			'display' => 'Català'
+			'display' => 'Català',
 		],
 		'da-DK' => [
 			'iso' => 'dk',
 			'name' => 'Danish',
-			'display' => 'Dansk'
+			'display' => 'Dansk',
 		],
 		'de-DE' => [
 			'iso' => 'de',
 			'name' => 'German',
-			'display' => 'Deutsch'
+			'display' => 'Deutsch',
 		],
 		'en-GB' => [
 			'iso' => 'uk',
 			'name' => 'English',
-			'display' => 'English'
+			'display' => 'English',
 		],
 		'es-CO' => [
 			'iso' => 'es-CO',
 			'name' => 'Spanish (Colombia)',
-			'display' => 'Español (Colombia)'
+			'display' => 'Español (Colombia)',
 		],
 		'es-ES' => [
 			'iso' => 'es',
 			'name' => 'Spanish',
-			'display' => 'Español'
+			'display' => 'Español',
 		],
 		'et-EE' => [
 			'iso' => 'ee',
 			'name' => 'Estonian',
-			'display' => 'Eesti'
+			'display' => 'Eesti',
 		],
 		'fr-CA' => [
 			'iso' => 'fr-CA',
 			'name' => 'French (Canada)',
-			'display' => 'Français (Canada)'
+			'display' => 'Français (Canada)',
 		],
 		'fr-FR' => [
 			'iso' => 'fr',
 			'name' => 'French',
-			'display' => 'Français'
+			'display' => 'Français',
 		],
 		'hu-HU' => [
 			'iso' => 'hu',
 			'name' => 'Hungarian',
-			'display' => 'Magyar'
+			'display' => 'Magyar',
 		],
 		'id-ID' => [
 			'iso' => 'id',
 			'name' => 'Indonesian',
-			'display' => 'Bahasa Indonesia'
+			'display' => 'Bahasa Indonesia',
 		],
 		'it-IT' => [
 			'iso' => 'it',
 			'name' => 'Italian',
-			'display' => 'Italiano'
+			'display' => 'Italiano',
 		],
 		'lv-LV' => [
 			'iso' => 'lv',
 			'name' => 'Latvian',
-			'display' => 'Latviešu valoda'
+			'display' => 'Latviešu valoda',
 		],
 		'nb-NO' => [
 			'iso' => 'nb',
 			'name' => 'Norwegian Bokmal',
-			'display' => 'Norsk bokmål'
+			'display' => 'Norsk bokmål',
 		],
 		'nl-BE' => [
 			'iso' => 'nl-BE',
 			'name' => 'Dutch (Belgium)',
-			'display' => 'Nederlands (België)'
+			'display' => 'Nederlands (België)',
 		],
 		'nl-NL' => [
 			'iso' => 'nl',
 			'name' => 'Dutch',
-			'display' => 'Nederlands'
+			'display' => 'Nederlands',
 		],
 		'pl-PL' => [
 			'iso' => 'pl',
 			'name' => 'Polish',
-			'display' => 'Język polski'
+			'display' => 'Język polski',
 		],
 		'pt-BR' => [
 			'iso' => 'br',
 			'name' => 'Portuguese Brazil',
-			'display' => 'Português Brazil'
+			'display' => 'Português Brazil',
 		],
 		'pt-PT' => [
 			'iso' => 'pt',
 			'name' => 'Portuguese',
-			'display' => 'Português'
+			'display' => 'Português',
 		],
 		'ro-RO' => [
 			'iso' => 'ro',
 			'name' => 'Romanian',
-			'display' => 'Limba română'
+			'display' => 'Limba română',
 		],
 		'ru-RU' => [
 			'iso' => 'ru',
 			'name' => 'Russian',
-			'display' => 'Русский'
+			'display' => 'Русский',
 		],
 		'sl-SI' => [
 			'iso' => 'sl',
 			'name' => 'Slovenian',
-			'display' => 'slovenski jezik'
+			'display' => 'slovenski jezik',
 		],
 		'zh-CN' => [
 			'iso' => 'cn',
 			'name' => 'Chinese',
-			'display' => '中文 (Zhōngwén)'
-		]
+			'display' => '中文 (Zhōngwén)',
+		],
 	];
 
 	/**
@@ -210,7 +210,7 @@ abstract class LanguageHelper
 			'CoreJS' => ['JTracker.js'],
 			'Template' => ['JTracker'],
 			'CLI' => ['cli'],
-			'App' => (new Filesystem(new Local(JPATH_ROOT . '/src/App')))->addPlugin(new ListPaths)->listPaths()
+			'App' => (new Filesystem(new Local(JPATH_ROOT . '/src/App')))->addPlugin(new ListPaths)->listPaths(),
 		];
 	}
 

--- a/src/JTracker/Model/AbstractTrackerListModel.php
+++ b/src/JTracker/Model/AbstractTrackerListModel.php
@@ -28,7 +28,7 @@ abstract class AbstractTrackerListModel extends AbstractTrackerDatabaseModel
 	 * @var    array
 	 * @since  1.0
 	 */
-	protected $cache = array();
+	protected $cache = [];
 
 	/**
 	 * Context string for the model type.  This is used to handle uniqueness

--- a/src/JTracker/Pagination/TrackerPagination.php
+++ b/src/JTracker/Pagination/TrackerPagination.php
@@ -130,7 +130,7 @@ class TrackerPagination
 		$lastPage = $this->getPagesTotal();
 		$lpm1     = $lastPage - 1;
 
-		$bar = array();
+		$bar = [];
 		$counter    = 0;
 
 		if ($lastPage < 2)

--- a/src/JTracker/Service/MonologProvider.php
+++ b/src/JTracker/Service/MonologProvider.php
@@ -90,10 +90,10 @@ class MonologProvider implements ServiceProviderInterface
 				return new Logger(
 					'JTracker',
 					[
-						$container->get('monolog.handler.application')
+						$container->get('monolog.handler.application'),
 					],
 					[
-						$container->get('monolog.processor.web')
+						$container->get('monolog.processor.web'),
 					]
 				);
 			}
@@ -106,11 +106,11 @@ class MonologProvider implements ServiceProviderInterface
 				return new Logger(
 					'JTracker',
 					[
-						$container->get('monolog.handler.database')
+						$container->get('monolog.handler.database'),
 					],
 					[
 						$container->get('monolog.processor.psr3'),
-						$container->get('monolog.processor.web')
+						$container->get('monolog.processor.web'),
 					]
 				);
 			}

--- a/src/JTracker/Service/RendererProvider.php
+++ b/src/JTracker/Service/RendererProvider.php
@@ -42,7 +42,7 @@ class RendererProvider implements ServiceProviderInterface
 					$rendererConfig = [
 						'path'  => JPATH_TEMPLATES,
 						'debug' => (bool) $config->get('debug.template', false),
-						'cache' => $config->get('renderer.cache', false) ? JPATH_ROOT . '/cache/' . $config->get('renderer.cache') : false
+						'cache' => $config->get('renderer.cache', false) ? JPATH_ROOT . '/cache/' . $config->get('renderer.cache') : false,
 					];
 
 					// Instantiate the renderer object
@@ -63,7 +63,7 @@ class RendererProvider implements ServiceProviderInterface
 							$renderer->getRenderer(), ['delimiters' => [
 							'tag_comment'  => ['{#', '#}'],
 							'tag_block'    => ['{%', '%}'],
-							'tag_variable' => ['{{', '}}']
+							'tag_variable' => ['{{', '}}'],
 						]]
 						)
 					);

--- a/src/JTracker/Upload/File.php
+++ b/src/JTracker/Upload/File.php
@@ -85,7 +85,7 @@ class File extends UploadFile implements \JsonSerializable
 	{
 		$validations = [
 			new Mimetype($this->application->get('validation.mime_types')),
-			new Size($this->application->get('validation.file_size'))
+			new Size($this->application->get('validation.file_size')),
 		];
 
 		// Txt has mime inconsistency on different environments,

--- a/src/JTracker/View/Renderer/TrackerExtension.php
+++ b/src/JTracker/View/Renderer/TrackerExtension.php
@@ -244,7 +244,7 @@ class TrackerExtension extends \Twig_Extension implements \Twig_Extension_Global
 			2 => g11n3t('Urgent'),
 			3 => g11n3t('Medium'),
 			4 => g11n3t('Low'),
-			5 => g11n3t('Very low')
+			5 => g11n3t('Very low'),
 		];
 	}
 
@@ -291,7 +291,7 @@ class TrackerExtension extends \Twig_Extension implements \Twig_Extension_Global
 			'duplicate_of' => g11n3t('Duplicate of'),
 			'related_to' => g11n3t('Related to'),
 			'not_before' => g11n3t('Not before'),
-			'pr_for' => g11n3t('Pull Request for')
+			'pr_for' => g11n3t('Pull Request for'),
 		];
 
 		return $relations[$relation];
@@ -354,7 +354,7 @@ class TrackerExtension extends \Twig_Extension implements \Twig_Extension_Global
 					3 => g11n3t('Pending'),
 					4 => g11n3t('Ready To Commit'),
 					6 => g11n3t('Needs Review'),
-					7 => g11n3t('Information Required')
+					7 => g11n3t('Information Required'),
 				];
 				break;
 
@@ -366,7 +366,7 @@ class TrackerExtension extends \Twig_Extension implements \Twig_Extension_Global
 					10 => g11n3t('Closed'),
 					11 => g11n3t('Expected Behaviour'),
 					12 => g11n3t('Known Issue'),
-					13 => g11n3t('Duplicate Report')
+					13 => g11n3t('Duplicate Report'),
 				];
 				break;
 
@@ -384,7 +384,7 @@ class TrackerExtension extends \Twig_Extension implements \Twig_Extension_Global
 					10 => g11n3t('Closed'),
 					11 => g11n3t('Expected Behaviour'),
 					12 => g11n3t('Known Issue'),
-					13 => g11n3t('Duplicate Report')
+					13 => g11n3t('Duplicate Report'),
 				];
 		}
 
@@ -693,7 +693,7 @@ class TrackerExtension extends \Twig_Extension implements \Twig_Extension_Global
 		$options = $options ? : [
 			0 => g11n3t('Not tested'),
 			1 => g11n3t('Tested successfully'),
-			2 => g11n3t('Tested unsuccessfully')
+			2 => g11n3t('Tested unsuccessfully'),
 		];
 
 		return ($id !== null && array_key_exists($id, $options)) ? $options[$id] : $options;


### PR DESCRIPTION
#### Summary of Changes

Adds support for the [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) tool as a means to help programmatically review and correct code style issues in PHP code.  This'll cover everything in the `cli` and `src` directories.

#### Testing Instructions

Review the package's documentation to ensure the selected fixers are in line with the project's code style rules and review the changes made to ensure they are consistent with the project's code style rules.

#### What About PHP_CodeSniffer

This is a tool to be used in addition to PHP_CodeSniffer, especially since Joomla's still using PHPCS 1.x which doesn't support auto-fixing.