### PR TITLE
Add initial support for "RTL" languages

### DIFF
--- a/src/JTracker/Helper/LanguageHelper.php
+++ b/src/JTracker/Helper/LanguageHelper.php
@@ -253,4 +253,21 @@ abstract class LanguageHelper
 
 		return $languages;
 	}
+
+	/**
+	 * Get the defined direction for a language.
+	 *
+	 * @param   string  $languageCode  The language code e.g. en-GB
+	 *
+	 * @return string 'ltr' or 'rtl'. Defaults to 'ltr'
+	 */
+	public static function getDirection($languageCode)
+	{
+		if (array_key_exists($languageCode, static::$languages))
+		{
+			return isset(static::$languages[$languageCode]['direction']) ? static::$languages[$languageCode]['direction'] : 'ltr';
+		}
+
+		return 'ltr';
+	}
 }

--- a/src/JTracker/View/Renderer/TrackerExtension.php
+++ b/src/JTracker/View/Renderer/TrackerExtension.php
@@ -80,13 +80,14 @@ class TrackerExtension extends \Twig_Extension implements \Twig_Extension_Global
 		return [
 			'uri'            => $this->app->get('uri'),
 			'offset'         => $this->app->getUser()->params->get('timezone') ?: $this->app->get('system.offset'),
+			'useCDN'         => $this->app->get('system.use_cdn'),
+			'templateDebug'  => $this->app->get('debug.template', false),
+			'jdebug'         => JDEBUG,
+			'lang'           => $this->app->getLanguageTag(),
 			'languages'      => LanguageHelper::getLanguagesSortedByDisplayName(),
 			'languageCodes'  => LanguageHelper::getLanguageCodes(),
-			'jdebug'         => JDEBUG,
-			'templateDebug'  => $this->app->get('debug.template', false),
-			'lang'           => $this->app->getLanguageTag(),
+			'langDirection'  => LanguageHelper::getDirection($this->app->getLanguageTag()),
 			'g11nJavaScript' => G11n::getJavaScript(),
-			'useCDN'         => $this->app->get('system.use_cdn'),
 		];
 	}
 

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -1,7 +1,7 @@
 {# Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved. #}
 {# GNU General Public License version 2 or later; see LICENSE.txt #}
 <!DOCTYPE html>
-<html lang="{{ lang|split("-")|first }}" dir="ltr">
+<html lang="{{ lang|split("-")|first }}" dir="{{ langDirection }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Pull Request for Issue #852  .

#### Summary of Changes
This will add initial support for "RTL" languages.

#### Testing Instructions
Add a new key to one of the existing languages defined in the [LanguageHelper](https://github.com/joomla/jissues/blob/master/src/JTracker/Helper/LanguageHelper.php#L45) class

    'direction' => 'rtl'

Or add a proper RTL language and set the key as shown.

Further improvements depends on input from a native speaker or someone with more knowledge than me on the subject.
