### PR TITLE
Fix: Notices in logs #862

### DIFF
--- a/src/App/Tracker/Controller/Issue/Submit.php
+++ b/src/App/Tracker/Controller/Issue/Submit.php
@@ -148,6 +148,10 @@ class Submit extends AbstractTrackerController
 		$data['issue_number']    = $data['number'];
 		$data['description_raw'] = $body;
 
+		// On submit the state is allways open; see #862
+		$data['new_state'] = 'open';
+		$data['old_state'] = 'open';
+
 		// Store the issue
 		try
 		{


### PR DESCRIPTION
Pull Request for Issue #862  .

#### Summary of Changes

In the submit controler we call the save method wihout the indexes `new_state` and `old_state` while this is expected the save method try to check on that field so we should fake it here.

#### Testing Instructions

Sumbit a item via the Tracker.

Check the logs
```
Undefined index: new_state in src/App/Tracker/Model/IssueModel.php on line 503
Undefined index: old_state in src/App/Tracker/Model/IssueModel.php on line 504
```

test againg with the patch.

#### Question (Other way arround)

Maybe we should move the check to the model?
so we have here: https://github.com/joomla/jissues/blob/master/src/App/Tracker/Model/IssueModel.php#L503-L504 something like:
```
// Assume open if nothing is set
$src['old_state'] = isset($src['old_state']) ? $src['old_state'] : 'open';	
$state = isset($src['new_state']) ? $src['new_state'] : 'open';
$changedState = $src['old_state'] != $state;
```