### PR TITLE
add path media/system/js/fields/calendar-locales to the TT handled folders

### DIFF
--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -104,6 +104,7 @@ class JoomlacmsPullsListener extends AbstractListener
 			'^administrator/language',
 			'^installation/language',
 			'^language',
+			'^media/system/js/fields/calendar-locales',
 		],
 		// Plugins
 		'28' => ['^plugins/'],

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -650,10 +650,12 @@ class JoomlacmsPullsListener extends AbstractListener
 		{
 			foreach ($files as $file)
 			{
-				// Check for file paths administrator/language, installation/language, and language at position 0
+				// Check for file paths administrator/language, installation/language,
+				// language and media/system/js/fields/calendar-locales at position 0
 				if (strpos($file->filename, 'administrator/language') === 0
 					|| strpos($file->filename, 'installation/language') === 0
-					|| strpos($file->filename, 'language') === 0)
+					|| strpos($file->filename, 'language') === 0
+					|| strpos($file->filename, 'media/system/js/fields/calendar-locales') === 0)
 				{
 					return true;
 				}

--- a/tests/tracker/Hooks/Listeners/JoomlaCmsPullsListenerCheckFilesAndAssignCategoryTest.php
+++ b/tests/tracker/Hooks/Listeners/JoomlaCmsPullsListenerCheckFilesAndAssignCategoryTest.php
@@ -88,7 +88,7 @@ class JoomlaCmsPullsListenerCheckFilesAndAssignCategoryTest extends \PHPUnit_Fra
 			'libraries/vendor/' => ['4', '12'],
 			'media/editors/codemirror' => ['4'],
 			'media/editors/tinymce' => ['4'],
-			'media/system/js/fields/calendar-locales/el.js' => ['27'],
+			'media/system/js/fields/calendar-locales/el.js' => ['1', '27'],
 			'modules/' => ['13', '24'],
 			'phpunit.xml.dist' => ['14'],
 			'plugins/' => ['24', '28'],

--- a/tests/tracker/Hooks/Listeners/JoomlaCmsPullsListenerCheckFilesAndAssignCategoryTest.php
+++ b/tests/tracker/Hooks/Listeners/JoomlaCmsPullsListenerCheckFilesAndAssignCategoryTest.php
@@ -88,6 +88,7 @@ class JoomlaCmsPullsListenerCheckFilesAndAssignCategoryTest extends \PHPUnit_Fra
 			'libraries/vendor/' => ['4', '12'],
 			'media/editors/codemirror' => ['4'],
 			'media/editors/tinymce' => ['4'],
+			'media/system/js/fields/calendar-locales/el.js' => ['27'],
 			'modules/' => ['13', '24'],
 			'phpunit.xml.dist' => ['14'],
 			'plugins/' => ['24', '28'],


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/13461#issuecomment-270239402

#### Summary of Changes

Add the folder media/system/js/fields/calendar-locales to the TT handled folders.

#### Testing Instructions

A change or a new file in that folder should add the language change label