### PR TITLE
Great new cs rules ...

### DIFF
--- a/src/App/Activity/ActivityApp.php
+++ b/src/App/Activity/ActivityApp.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Controller/AbstractBaseController.php
+++ b/src/App/Activity/Controller/AbstractBaseController.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Controller/ActivitySnapshotController.php
+++ b/src/App/Activity/Controller/ActivitySnapshotController.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Controller/Ajax/ActivitySnapshot.php
+++ b/src/App/Activity/Controller/Ajax/ActivitySnapshot.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Controller/Ajax/ProjectActivity.php
+++ b/src/App/Activity/Controller/Ajax/ProjectActivity.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Controller/Ajax/TotalActivity.php
+++ b/src/App/Activity/Controller/Ajax/TotalActivity.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Controller/Ajax/UserActivity.php
+++ b/src/App/Activity/Controller/Ajax/UserActivity.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Controller/ProjectActivityController.php
+++ b/src/App/Activity/Controller/ProjectActivityController.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Controller/TotalActivityController.php
+++ b/src/App/Activity/Controller/TotalActivityController.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Controller/UserActivityController.php
+++ b/src/App/Activity/Controller/UserActivityController.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Model/ProjectactivityModel.php
+++ b/src/App/Activity/Model/ProjectactivityModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Model/SnapshotModel.php
+++ b/src/App/Activity/Model/SnapshotModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Model/TotaluseractivityModel.php
+++ b/src/App/Activity/Model/TotaluseractivityModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/Model/UseractivityModel.php
+++ b/src/App/Activity/Model/UseractivityModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Activity/View/DefaultHtmlView.php
+++ b/src/App/Activity/View/DefaultHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Activity Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Debug/Controller/Debug.php
+++ b/src/App/Debug/Controller/Debug.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Debug Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Debug/Controller/Logs.php
+++ b/src/App/Debug/Controller/Logs.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Debug Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Debug/Database/DatabaseDebugger.php
+++ b/src/App/Debug/Database/DatabaseDebugger.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Debug Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Debug/DebugApp.php
+++ b/src/App/Debug/DebugApp.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Debug Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Debug/Format/Html/LinkFormat.php
+++ b/src/App/Debug/Format/Html/LinkFormat.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Debug Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Debug/Format/Html/SqlFormat.php
+++ b/src/App/Debug/Format/Html/SqlFormat.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Debug Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Debug/Format/Html/TableFormat.php
+++ b/src/App/Debug/Format/Html/TableFormat.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Debug Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Debug/Handler/ProductionHandler.php
+++ b/src/App/Debug/Handler/ProductionHandler.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Debug Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Debug/Model/DefaultModel.php
+++ b/src/App/Debug/Model/DefaultModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Debug Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Debug/TrackerDebugger.php
+++ b/src/App/Debug/TrackerDebugger.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla! Tracker application.
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Debug/View/Logs/LogsHtmlView.php
+++ b/src/App/Debug/View/Logs/LogsHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla! Tracker application.
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Controller/Ajax/Hooks/Add.php
+++ b/src/App/GitHub/Controller/Ajax/Hooks/Add.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Controller/Ajax/Hooks/GetList.php
+++ b/src/App/GitHub/Controller/Ajax/Hooks/GetList.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Controller/Ajax/Hooks/Modify.php
+++ b/src/App/GitHub/Controller/Ajax/Hooks/Modify.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Controller/Ajax/Labels/Add.php
+++ b/src/App/GitHub/Controller/Ajax/Labels/Add.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Controller/Ajax/Labels/Delete.php
+++ b/src/App/GitHub/Controller/Ajax/Labels/Delete.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Controller/Ajax/Labels/GetList.php
+++ b/src/App/GitHub/Controller/Ajax/Labels/GetList.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Controller/Ajax/Markdown/Preview.php
+++ b/src/App/GitHub/Controller/Ajax/Markdown/Preview.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Controller/Hooks.php
+++ b/src/App/GitHub/Controller/Hooks.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Controller/Labels.php
+++ b/src/App/GitHub/Controller/Labels.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Controller/Milestones.php
+++ b/src/App/GitHub/Controller/Milestones.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Controller/Stats.php
+++ b/src/App/GitHub/Controller/Stats.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/GitHubApp.php
+++ b/src/App/GitHub/GitHubApp.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/Model/DefaultModel.php
+++ b/src/App/GitHub/Model/DefaultModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/GitHub/View/Stats/StatsHtmlView.php
+++ b/src/App/GitHub/View/Stats/StatsHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/Controller/Group.php
+++ b/src/App/Groups/Controller/Group.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/Controller/Group/Add.php
+++ b/src/App/Groups/Controller/Group/Add.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/Controller/Group/Delete.php
+++ b/src/App/Groups/Controller/Group/Delete.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/Controller/Group/Save.php
+++ b/src/App/Groups/Controller/Group/Save.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/Controller/Groups.php
+++ b/src/App/Groups/Controller/Groups.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/GroupsApp.php
+++ b/src/App/Groups/GroupsApp.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/Model/DefaultModel.php
+++ b/src/App/Groups/Model/DefaultModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/Model/GroupModel.php
+++ b/src/App/Groups/Model/GroupModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/Model/GroupsModel.php
+++ b/src/App/Groups/Model/GroupsModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/Table/GroupsTable.php
+++ b/src/App/Groups/Table/GroupsTable.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/View/Group/GroupHtmlView.php
+++ b/src/App/Groups/View/Group/GroupHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Groups/View/Groups/GroupsHtmlView.php
+++ b/src/App/Groups/View/Groups/GroupsHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Groups Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/Controller/Project.php
+++ b/src/App/Projects/Controller/Project.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/Controller/Project/Add.php
+++ b/src/App/Projects/Controller/Project/Add.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/Controller/Project/Delete.php
+++ b/src/App/Projects/Controller/Project/Delete.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/Controller/Project/Edit.php
+++ b/src/App/Projects/Controller/Project/Edit.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/Controller/Project/Save.php
+++ b/src/App/Projects/Controller/Project/Save.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/Controller/Projects.php
+++ b/src/App/Projects/Controller/Projects.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/Model/ProjectModel.php
+++ b/src/App/Projects/Model/ProjectModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/Model/ProjectsModel.php
+++ b/src/App/Projects/Model/ProjectsModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/ProjectAwareTrait.php
+++ b/src/App/Projects/ProjectAwareTrait.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/ProjectsApp.php
+++ b/src/App/Projects/ProjectsApp.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/Table/LabelsTable.php
+++ b/src/App/Projects/Table/LabelsTable.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/Table/MilestonesTable.php
+++ b/src/App/Projects/Table/MilestonesTable.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/Table/ProjectsTable.php
+++ b/src/App/Projects/Table/ProjectsTable.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/TrackerProject.php
+++ b/src/App/Projects/TrackerProject.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/View/Project/ProjectHtmlView.php
+++ b/src/App/Projects/View/Project/ProjectHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Projects/View/Projects/ProjectsHtmlView.php
+++ b/src/App/Projects/View/Projects/ProjectsHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Support/Controller/Ajax/Documentation/Show.php
+++ b/src/App/Support/Controller/Ajax/Documentation/Show.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's GitHub Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Support/Controller/Clearcache.php
+++ b/src/App/Support/Controller/Clearcache.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Support/Controller/Documentation.php
+++ b/src/App/Support/Controller/Documentation.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Support/Controller/Filetree.php
+++ b/src/App/Support/Controller/Filetree.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Support/Controller/Icons.php
+++ b/src/App/Support/Controller/Icons.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Support/Controller/Markdown.php
+++ b/src/App/Support/Controller/Markdown.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Support/Model/DefaultModel.php
+++ b/src/App/Support/Model/DefaultModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Support/SupportApp.php
+++ b/src/App/Support/SupportApp.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Support/View/Icons/IconsHtmlView.php
+++ b/src/App/Support/View/Icons/IconsHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/System/Controller/Config.php
+++ b/src/App/System/Controller/Config.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/System/Controller/Config/Save.php
+++ b/src/App/System/Controller/Config/Save.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/System/Controller/PhpInfo.php
+++ b/src/App/System/Controller/PhpInfo.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/System/Controller/Routes.php
+++ b/src/App/System/Controller/Routes.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/System/Controller/WrongCms.php
+++ b/src/App/System/Controller/WrongCms.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/System/Model/DefaultModel.php
+++ b/src/App/System/Model/DefaultModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/System/SystemApp.php
+++ b/src/App/System/SystemApp.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's System Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/System/View/Config/ConfigHtmlView.php
+++ b/src/App/System/View/Config/ConfigHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/System/View/Phpinfo/PhpinfoHtmlView.php
+++ b/src/App/System/View/Phpinfo/PhpinfoHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Support Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/Controller/Article/Add.php
+++ b/src/App/Text/Controller/Article/Add.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/Controller/Article/Delete.php
+++ b/src/App/Text/Controller/Article/Delete.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/Controller/Article/Edit.php
+++ b/src/App/Text/Controller/Article/Edit.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/Controller/Article/Save.php
+++ b/src/App/Text/Controller/Article/Save.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/Controller/Articles.php
+++ b/src/App/Text/Controller/Articles.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/Controller/Page.php
+++ b/src/App/Text/Controller/Page.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/Model/ArticleModel.php
+++ b/src/App/Text/Model/ArticleModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/Model/ArticlesModel.php
+++ b/src/App/Text/Model/ArticlesModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/Model/PageModel.php
+++ b/src/App/Text/Model/PageModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/Table/ArticlesTable.php
+++ b/src/App/Text/Table/ArticlesTable.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/TextApp.php
+++ b/src/App/Text/TextApp.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/View/Article/ArticleHtmlView.php
+++ b/src/App/Text/View/Article/ArticleHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/View/Articles/ArticlesHtmlView.php
+++ b/src/App/Text/View/Articles/ArticlesHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Text/View/Page/PageHtmlView.php
+++ b/src/App/Text/View/Page/PageHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Text Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/AbstractHookController.php
+++ b/src/App/Tracker/Controller/AbstractHookController.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Category/Delete.php
+++ b/src/App/Tracker/Controller/Category/Delete.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Category/Edit.php
+++ b/src/App/Tracker/Controller/Category/Edit.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Category/Listing.php
+++ b/src/App/Tracker/Controller/Category/Listing.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Category/Save.php
+++ b/src/App/Tracker/Controller/Category/Save.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Projects Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Comment/Ajax/Submit.php
+++ b/src/App/Tracker/Controller/Comment/Ajax/Submit.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/DefaultController.php
+++ b/src/App/Tracker/Controller/DefaultController.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsCommentsListener.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Hooks/Listeners/TestsItemsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/TestsItemsListener.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Hooks/ReceiveIssuesHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveIssuesHook.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullsHook.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Issue/Add.php
+++ b/src/App/Tracker/Controller/Issue/Add.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Issue/Ajax/Info.php
+++ b/src/App/Tracker/Controller/Issue/Ajax/Info.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Issue/Ajax/Listing.php
+++ b/src/App/Tracker/Controller/Issue/Ajax/Listing.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Model Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Issue/Ajax/Vote.php
+++ b/src/App/Tracker/Controller/Issue/Ajax/Vote.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Issue/Edit.php
+++ b/src/App/Tracker/Controller/Issue/Edit.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Issue/Item.php
+++ b/src/App/Tracker/Controller/Issue/Item.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Issue/Listing.php
+++ b/src/App/Tracker/Controller/Issue/Listing.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Issue/Submit.php
+++ b/src/App/Tracker/Controller/Issue/Submit.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/TestResult/Ajax/Alter.php
+++ b/src/App/Tracker/Controller/TestResult/Ajax/Alter.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/TestResult/Ajax/Submit.php
+++ b/src/App/Tracker/Controller/TestResult/Ajax/Submit.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Upload/Ajax/Delete.php
+++ b/src/App/Tracker/Controller/Upload/Ajax/Delete.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Controller/Upload/Ajax/Put.php
+++ b/src/App/Tracker/Controller/Upload/Ajax/Put.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Exception/ValidationException.php
+++ b/src/App/Tracker/Exception/ValidationException.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Model/ActivityModel.php
+++ b/src/App/Tracker/Model/ActivityModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Model/CategoriesModel.php
+++ b/src/App/Tracker/Model/CategoriesModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Model/CategoryModel.php
+++ b/src/App/Tracker/Model/CategoryModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Model/DefaultModel.php
+++ b/src/App/Tracker/Model/DefaultModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Model/IssueModel.php
+++ b/src/App/Tracker/Model/IssueModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Model/IssuesModel.php
+++ b/src/App/Tracker/Model/IssuesModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Table/ActivitiesTable.php
+++ b/src/App/Tracker/Table/ActivitiesTable.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Table/CategoryTable.php
+++ b/src/App/Tracker/Table/CategoryTable.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Table/IssueCategoryMappingTable.php
+++ b/src/App/Tracker/Table/IssueCategoryMappingTable.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Table/IssuesTable.php
+++ b/src/App/Tracker/Table/IssuesTable.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/Table/StatusTable.php
+++ b/src/App/Tracker/Table/StatusTable.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/TrackerApp.php
+++ b/src/App/Tracker/TrackerApp.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/View/Issue/IssueHtmlView.php
+++ b/src/App/Tracker/View/Issue/IssueHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Tracker/View/Issues/IssuesHtmlView.php
+++ b/src/App/Tracker/View/Issues/IssuesHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Controller/Ajax/Assign.php
+++ b/src/App/Users/Controller/Ajax/Assign.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Controller/Ajax/Listing.php
+++ b/src/App/Users/Controller/Ajax/Listing.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Controller/Ajax/Search.php
+++ b/src/App/Users/Controller/Ajax/Search.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Controller/Login.php
+++ b/src/App/Users/Controller/Login.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Controller/Logout.php
+++ b/src/App/Users/Controller/Logout.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Controller/User.php
+++ b/src/App/Users/Controller/User.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Controller/User/Edit.php
+++ b/src/App/Users/Controller/User/Edit.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Controller/User/Refresh.php
+++ b/src/App/Users/Controller/User/Refresh.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Controller/User/Save.php
+++ b/src/App/Users/Controller/User/Save.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Tracker Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Controller/Users.php
+++ b/src/App/Users/Controller/Users.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Model/DefaultModel.php
+++ b/src/App/Users/Model/DefaultModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Model/UserModel.php
+++ b/src/App/Users/Model/UserModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/Model/UsersModel.php
+++ b/src/App/Users/Model/UsersModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/UsersApp.php
+++ b/src/App/Users/UsersApp.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/View/User/UserHtmlView.php
+++ b/src/App/Users/View/User/UserHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/App/Users/View/Users/UsersHtmlView.php
+++ b/src/App/Users/View/Users/UsersHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker's Users Application
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/AppInterface.php
+++ b/src/JTracker/AppInterface.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Application.php
+++ b/src/JTracker/Application.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/ApplicationTrait.php
+++ b/src/JTracker/ApplicationTrait.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Authentication/Database/TableUsers.php
+++ b/src/JTracker/Authentication/Database/TableUsers.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Authentication Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Authentication/Exception/AuthenticationException.php
+++ b/src/JTracker/Authentication/Exception/AuthenticationException.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Authentication Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Authentication/GitHub/GitHubLoginHelper.php
+++ b/src/JTracker/Authentication/GitHub/GitHubLoginHelper.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Authentication Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Authentication/GitHub/GitHubUser.php
+++ b/src/JTracker/Authentication/GitHub/GitHubUser.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Authentication Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Authentication/User.php
+++ b/src/JTracker/Authentication/User.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Authentication Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Controller/AbstractAjaxController.php
+++ b/src/JTracker/Controller/AbstractAjaxController.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Controller Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Controller/AbstractTrackerController.php
+++ b/src/JTracker/Controller/AbstractTrackerController.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Controller Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Controller/AbstractTrackerListController.php
+++ b/src/JTracker/Controller/AbstractTrackerListController.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Controller Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Controller/AjaxResponse.php
+++ b/src/JTracker/Controller/AjaxResponse.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Controller Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Database/AbstractDatabaseTable.php
+++ b/src/JTracker/Database/AbstractDatabaseTable.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Database Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Database/Migrations.php
+++ b/src/JTracker/Database/Migrations.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Database Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Github/GithubFactory.php
+++ b/src/JTracker/Github/GithubFactory.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Github Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/JTracker/Helper/IpHelper.php
+++ b/src/JTracker/Helper/IpHelper.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Http/CurlTransport.php
+++ b/src/JTracker/Http/CurlTransport.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Model/AbstractTrackerDatabaseModel.php
+++ b/src/JTracker/Model/AbstractTrackerDatabaseModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Model Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Model/AbstractTrackerListModel.php
+++ b/src/JTracker/Model/AbstractTrackerListModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Model Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Model/TrackerDefaultModel.php
+++ b/src/JTracker/Model/TrackerDefaultModel.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Model Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Pagination/TrackerPagination.php
+++ b/src/JTracker/Pagination/TrackerPagination.php
@@ -6,7 +6,7 @@
  * http://www.awcore.com/dev/1/3/Create-Awesome-PHPMYSQL-Pagination_en
  * and modified by "The Joomla! Tracker Project".
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Router/Exception/RoutingException.php
+++ b/src/JTracker/Router/Exception/RoutingException.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Router Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Router/TrackerRouter.php
+++ b/src/JTracker/Router/TrackerRouter.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Router Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Service/CacheProvider.php
+++ b/src/JTracker/Service/CacheProvider.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Service Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Service/CliApplicationProvider.php
+++ b/src/JTracker/Service/CliApplicationProvider.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Service Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Service/ConfigurationProvider.php
+++ b/src/JTracker/Service/ConfigurationProvider.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Service Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Service/DatabaseProvider.php
+++ b/src/JTracker/Service/DatabaseProvider.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Service Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Service/DebuggerProvider.php
+++ b/src/JTracker/Service/DebuggerProvider.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Service Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Service/DispatcherProvider.php
+++ b/src/JTracker/Service/DispatcherProvider.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Service Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Service/GitHubProvider.php
+++ b/src/JTracker/Service/GitHubProvider.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Service Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Service/MonologProvider.php
+++ b/src/JTracker/Service/MonologProvider.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Service Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Service/RendererProvider.php
+++ b/src/JTracker/Service/RendererProvider.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Service Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Service/TransifexProvider.php
+++ b/src/JTracker/Service/TransifexProvider.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Service Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Service/WebApplicationProvider.php
+++ b/src/JTracker/Service/WebApplicationProvider.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker Service Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/Upload/File.php
+++ b/src/JTracker/Upload/File.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/View/AbstractTrackerHtmlView.php
+++ b/src/JTracker/View/AbstractTrackerHtmlView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker View Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/View/Renderer/ApplicationContext.php
+++ b/src/JTracker/View/Renderer/ApplicationContext.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker View Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/View/Renderer/DebugPathPackage.php
+++ b/src/JTracker/View/Renderer/DebugPathPackage.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker View Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/View/Renderer/TrackerExtension.php
+++ b/src/JTracker/View/Renderer/TrackerExtension.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker View Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 

--- a/src/JTracker/View/TrackerDefaultView.php
+++ b/src/JTracker/View/TrackerDefaultView.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Tracker View Package
  *
- * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2012-2014 Open Source Matters, Inc. All rights reserved.
  * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/jissues/pull/945#issuecomment-280748065

#### Summary of Changes

It looks like we have new CS rules?

```
FILE: ...ravis/build/joomla/jissues/cli/Application/Command/Export/Langfiles.php
--------------------------------------------------------------------------------
FOUND 1 ERROR(S) AND 1 WARNING(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 5 | WARNING | Invalid year span "2012" found; consider "-2012" instead
 5 | ERROR   | A hyphen must be used between the earliest and latest year
--------------------------------------------------------------------------------
UPGRADE TO PHP_CODESNIFFER 2.0 TO FIX ERRORS AUTOMATICALLY
--------------------------------------------------------------------------------
```

#### Testing Instructions

Lets see if travis is now ok?