### PR TITLE
Add WIP on recieving webhooks for pull request reviews

### DIFF
--- a/cli/Application/Command/Test/Hook.php
+++ b/cli/Application/Command/Test/Hook.php
@@ -149,7 +149,7 @@ class Hook extends Test
 		$this->controller = new $classname;
 		$this->controller->setContainer($this->getContainer());
 
-		if ($this->project->project_id === '1' && $resp === 3)
+		if ($this->project->project_id === '1' && $resp === 4)
 		{
 			$this->getApplication()->input->post->set('payload', file_get_contents(__DIR__ . '/data/cms-pull.json'));
 		}

--- a/etc/migrations/20170723001.sql
+++ b/etc/migrations/20170723001.sql
@@ -1,0 +1,26 @@
+# Table for Pull Request Reviews
+
+--
+-- Table structure for table `#__issues_reviews`
+--
+CREATE TABLE `#__issue_reviews` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT COMMENT 'PK',
+  `issue_id` int(11) unsigned NOT NULL COMMENT 'PK of the issue in issue table',
+  `project_id` int(11) NOT NULL COMMENT 'The Project id',
+  `review_id` int(11) unsigned NOT NULL COMMENT 'The GitHub ID of the review',
+  `review_state` int(11) unsigned NOT NULL COMMENT 'The ',
+  `reviewed_by` varchar(150) NOT NULL COMMENT 'Reviewed by username',
+  `review_comment` varchar(500) NULL DEFAULT NULL COMMENT 'The comment associated with the review',
+  `review_submitted` datetime DEFAULT NULL COMMENT 'Date the review was last updated on.',
+  `dismissed_by` varchar(150) NULL DEFAULT NULL COMMENT 'Reviewed by username',
+  `dismissed_comment` varchar(500) NULL DEFAULT NULL COMMENT 'The comment associated with the review',
+  `dismissed_on` datetime DEFAULT NULL COMMENT 'Date the review was dismissed on.',
+  PRIMARY KEY (`id`),
+  KEY `issue_number` (`issue_id`),
+  KEY `project_id` (`project_id`),
+  KEY `review_id` (`review_id`),
+  KEY `issue_project_index`(`issue_id`, `project_id`),
+  UNIQUE (`review_id`),
+  CONSTRAINT `#__issue_reviews_iifk` FOREIGN KEY (`issue_id`) REFERENCES `#__issues` (`issue_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `#__issue_reviews_pifk` FOREIGN KEY (`project_id`) REFERENCES `#__tracker_projects` (`project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/etc/migrations/20170723001.sql
+++ b/etc/migrations/20170723001.sql
@@ -21,6 +21,6 @@ CREATE TABLE `#__issue_reviews` (
   KEY `review_id` (`review_id`),
   KEY `issue_project_index`(`issue_id`, `project_id`),
   UNIQUE (`review_id`),
-  CONSTRAINT `#__issue_reviews_iifk` FOREIGN KEY (`issue_id`) REFERENCES `#__issues` (`issue_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `#__issue_reviews_iifk` FOREIGN KEY (`issue_id`) REFERENCES `#__issues` (`issue_number`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `#__issue_reviews_pifk` FOREIGN KEY (`project_id`) REFERENCES `#__tracker_projects` (`project_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/etc/mysql.sql
+++ b/etc/mysql.sql
@@ -400,6 +400,37 @@ CREATE TABLE `#__issue_category_map` (
   CONSTRAINT `#__issue_category_map_ibfk_2` FOREIGN KEY (`category_id`) REFERENCES `#__issues_categories` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `#__issues_reviews`
+--
+CREATE TABLE `#__issue_reviews` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT COMMENT 'PK',
+  `issue_id` int(11) unsigned NOT NULL COMMENT 'PK of the issue in issue table',
+  `project_id` int(11) NOT NULL COMMENT 'The Project id',
+  `review_id` int(11) unsigned NOT NULL COMMENT 'The GitHub ID of the review',
+  `review_state` int(11) unsigned NOT NULL COMMENT 'The ',
+  `reviewed_by` varchar(150) NOT NULL COMMENT 'Reviewed by username',
+  `review_comment` varchar(500) NULL DEFAULT NULL COMMENT 'The comment associated with the review',
+  `review_submitted` datetime DEFAULT NULL COMMENT 'Date the review was last updated on.',
+  `dismissed_by` varchar(150) NULL DEFAULT NULL COMMENT 'Reviewed by username',
+  `dismissed_comment` varchar(500) NULL DEFAULT NULL COMMENT 'The comment associated with the review',
+  `dismissed_on` datetime DEFAULT NULL COMMENT 'Date the review was dismissed on.',
+  PRIMARY KEY (`id`),
+  KEY `issue_number` (`issue_id`),
+  KEY `project_id` (`project_id`),
+  KEY `review_id` (`review_id`),
+  KEY `issue_project_index`(`issue_id`, `project_id`),
+  UNIQUE (`review_id`),
+  CONSTRAINT `#__issue_reviews_iifk` FOREIGN KEY (`issue_id`) REFERENCES `#__issues` (`issue_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `#__issue_reviews_pifk` FOREIGN KEY (`project_id`) REFERENCES `#__tracker_projects` (`project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+
+
+-- --------------------------------------------------------
+
 --
 -- Table structure for table `#__migrations`
 --
@@ -411,4 +442,5 @@ CREATE TABLE `#__migrations` (
 INSERT INTO `#__migrations` (`version`) VALUES
 ('20160611001'),
 ('20160612001'),
-('20160612002');
+('20160612002'),
+('20170723001');

--- a/etc/mysql.sql
+++ b/etc/mysql.sql
@@ -424,7 +424,7 @@ CREATE TABLE `#__issue_reviews` (
   KEY `review_id` (`review_id`),
   KEY `issue_project_index`(`issue_id`, `project_id`),
   UNIQUE (`review_id`),
-  CONSTRAINT `#__issue_reviews_iifk` FOREIGN KEY (`issue_id`) REFERENCES `#__issues` (`issue_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `#__issue_reviews_iifk` FOREIGN KEY (`issue_id`) REFERENCES `#__issues` (`issue_number`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `#__issue_reviews_pifk` FOREIGN KEY (`project_id`) REFERENCES `#__tracker_projects` (`project_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 

--- a/src/App/Tracker/Controller/Hooks/ReceivePullReviewHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullReviewHook.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Tracker Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Tracker\Controller\Hooks;
+
+use App\Tracker\Controller\AbstractHookController;
+use App\Tracker\Table\ReviewsTable;
+use Joomla\Date\Date;
+
+/**
+ * Controller class receive and inject pull request review webhook events from GitHub.
+ *
+ * @since  1.0
+ */
+class ReceivePullReviewHook extends AbstractHookController
+{
+	/**
+	 * The type of hook being executed
+	 *
+	 * @var    string
+	 * @since  1.0
+	 */
+	protected $type = 'pullReview';
+
+	/**
+	 * Prepare the response.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   1.0
+	 */
+	protected function prepareResponse()
+	{
+		if (!isset($this->hookData->pull_request->number) || !is_object($this->hookData))
+		{
+			// If we can't get the issue number exit.
+			$this->response->message = 'Hook data does not exist.';
+
+			return;
+		}
+
+		// If the item is already in the database, update it; else, insert it.
+		if (!$this->checkIssueExists((int) $this->hookData->pull_request->number))
+		{
+			$this->response->message = 'Pull Request does not exist in the system.';
+
+			return;
+		}
+
+		try
+		{
+			$this->updateData();
+		}
+		catch (\Exception $e)
+		{
+			$logMessage = 'Uncaught Exception processing pull request webhook';
+
+			$this->logger->critical($logMessage, ['exception' => $e]);
+			$this->setStatusCode(500);
+			$this->response->error = $logMessage . ': ' . $e->getMessage();
+			$this->response->message = 'Hook data processed unsuccessfully.';
+		}
+	}
+
+	/**
+	 * Method to update data for an issue from GitHub
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	protected function updateData()
+	{
+		try
+		{
+			$table = (new ReviewsTable($this->db))->load(
+				[
+					'issue_number' => $this->hookData->pull_request->number,
+					'project_id' => $this->project->project_id,
+				]
+			);
+		}
+		catch (\Exception $e)
+		{
+			$logMessage = sprintf(
+				'Error loading GitHub issue %s/%s #%d in the tracker',
+				$this->project->gh_user,
+				$this->project->gh_project,
+				$this->hookData->pull_request->number
+			);
+			$this->setStatusCode(500);
+			$this->response->error = $logMessage . ': ' . $e->getMessage();
+			$this->logger->error($logMessage, ['exception' => $e]);
+
+			return;
+		}
+
+		$action = $this->hookData->action;
+
+		switch ($action)
+		{
+			case 'submitted':
+				// Prepare the dates for insertion to the database
+				$dateFormat = $this->db->getDateFormat();
+
+				$data = [
+					'issue_id'         => $this->hookData->pull_request->number,
+					'project_id'       => $this->project->project_id,
+					'review_id'        => $this->hookData->review->id,
+					'review_state'     => $this->hookData->review->state,
+					'reviewed_by'      => $this->hookData->review->user->login,
+					'review_comment'   => $this->hookData->review->body,
+					'review_submitted' => (new Date($this->hookData->issue->created_at))->format($dateFormat),
+				];
+
+				try
+				{
+					$table->save($data);
+				}
+				catch (\Exception $e)
+				{
+					$logMessage = sprintf(
+						'Error adding GitHub review %s/%s #%d (review #%d) in the tracker',
+						$this->project->gh_user,
+						$this->project->gh_project,
+						$this->hookData->pull_request->number,
+						$this->hookData->review->id
+					);
+					$this->setStatusCode(500);
+					$this->response->error = $logMessage . ': ' . $e->getMessage();
+					$this->logger->error($logMessage, ['exception' => $e]);
+
+					return;
+				}
+
+				try
+				{
+					$this->triggerEvent('onIssueAfterGithubReview', ['table' => $table, 'action' => $action]);
+				}
+				catch (\Exception $e)
+				{
+					$logMessage = sprintf(
+						'Error processing `onIssueAfterGithubReview` event for issue number %d, review %d',
+						$this->hookData->pull_request->number,
+						$this->hookData->review->id
+					);
+					$this->setStatusCode(500);
+					$this->response->error = $logMessage . ': ' . $e->getMessage();
+					$this->logger->error($logMessage, ['exception' => $e]);
+
+					return;
+				}
+
+				// Pull the user's avatar if it does not exist
+				$this->pullUserAvatar($this->hookData->review->user->login);
+
+				$this->response->message = 'Hook data processed successfully.';
+
+				break;
+
+			case 'edited':
+				// Prepare the dates for insertion to the database
+				$dateFormat = $this->db->getDateFormat();
+
+				// TODO: Do we want to save in the activities table who changed the review?
+				$data = [
+					'review_comment'   => $this->hookData->changes->body,
+					'review_submitted' => (new Date($this->hookData->issue->created_at))->format($dateFormat),
+				];
+
+				$table->load(
+					array('review_id' => $this->hookData->review->id)
+				);
+
+				try
+				{
+					$table->save($data);
+				}
+				catch (\Exception $e)
+				{
+					$logMessage = sprintf(
+						'Error updating GitHub review %s/%s #%d (review #%d) in the tracker',
+						$this->project->gh_user,
+						$this->project->gh_project,
+						$this->hookData->pull_request->number,
+						$this->hookData->review->id
+					);
+					$this->setStatusCode(500);
+					$this->response->error = $logMessage . ': ' . $e->getMessage();
+					$this->logger->error($logMessage, ['exception' => $e]);
+
+					return;
+				}
+
+				$this->response->message = 'Hook data processed successfully.';
+
+				break;
+
+			case 'dismissed':
+				// Prepare the dates for insertion to the database
+				$dateFormat = $this->db->getDateFormat();
+
+				// TODO: Where is the dismissed comment stored in the hook data??
+				$data = [
+					'dismissed_by'      => $this->hookData->changes->body,
+					'dismissed_on'      => (new Date($this->hookData->issue->created_at))->format($dateFormat),
+					// 'dismissed_comment' => $this->hookData->changes->body,
+				];
+
+				$table->load(
+					array('review_id' => $this->hookData->review->id)
+				);
+
+				try
+				{
+					$table->save($data);
+				}
+				catch (\Exception $e)
+				{
+					$logMessage = sprintf(
+						'Error updating GitHub review %s/%s #%d (review #%d) in the tracker',
+						$this->project->gh_user,
+						$this->project->gh_project,
+						$this->hookData->pull_request->number,
+						$this->hookData->review->id
+					);
+					$this->setStatusCode(500);
+					$this->response->error = $logMessage . ': ' . $e->getMessage();
+					$this->logger->error($logMessage, ['exception' => $e]);
+
+					return;
+				}
+
+				$this->response->message = 'Hook data processed successfully.';
+
+				break;
+
+			default:
+				$this->response->data = (object) [
+					'processed' => false,
+					'reason'    => "The '$action' action is not supported by this webhook.",
+				];
+
+				$this->response->message = 'Hook data not processed.';
+
+				break;
+		}
+	}
+}

--- a/src/App/Tracker/Table/ReviewsTable.php
+++ b/src/App/Tracker/Table/ReviewsTable.php
@@ -29,6 +29,21 @@ use JTracker\Database\AbstractDatabaseTable;
 class ReviewsTable extends AbstractDatabaseTable
 {
 	/**
+	 * Review approved state
+	 */
+	const APPROVED_STATE = 1;
+
+	/**
+	 * Review approved state
+	 */
+	const CHANGES_REQUIRED_STATE = 2;
+
+	/**
+	 * Review approved state
+	 */
+	const DISMISSED_STATE = 3;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   DatabaseDriver  $database  A database connector object.

--- a/src/App/Tracker/Table/ReviewsTable.php
+++ b/src/App/Tracker/Table/ReviewsTable.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Part of the Joomla Tracker's Tracker Application
+ *
+ * @copyright  Copyright (C) 2012 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+namespace App\Tracker\Table;
+
+use Joomla\Database\DatabaseDriver;
+
+use JTracker\Database\AbstractDatabaseTable;
+
+/**
+ * Table interface class for the #__status table
+ *
+ * @property   integer  $id                 ID
+ * @property   integer  $review_state       Review state
+ * @property   string   $reviewed_by        The username of the person who made the review
+ * @property   string   $review_comment     The comment associated with the review
+ * @property   string   $review_submitted   The date the review was submitted on
+ * @property   string   $dismissed_by       The username of the person who made the review
+ * @property   string   $dismissed_on       The date the review was dismissed on
+ * @property   string   $dismissed_comment  The comment associated with the review
+ *
+ * @since  1.0
+ */
+class ReviewsTable extends AbstractDatabaseTable
+{
+	/**
+	 * Constructor
+	 *
+	 * @param   DatabaseDriver  $database  A database connector object.
+	 *
+	 * @since   1.0
+	 */
+	public function __construct(DatabaseDriver $database)
+	{
+		parent::__construct('#__issue_reviews', 'id', $database);
+	}
+}

--- a/src/App/Tracker/routes.json
+++ b/src/App/Tracker/routes.json
@@ -4,6 +4,7 @@
 	"hooks/issues"  : "\\Tracker\\Controller\\Hooks\\ReceiveIssuesHook",
 	"hooks/pulls"   : "\\Tracker\\Controller\\Hooks\\ReceivePullsHook",
 	"hooks/comments": "\\Tracker\\Controller\\Hooks\\ReceiveCommentsHook",
+	"hooks/pull_reviews": "\\Tracker\\Controller\\Hooks\\ReceivePullReviewHook",
 
 	"tracker/:project_alias"              : "\\Tracker\\Controller\\Issue\\Listing",
 	"tracker/:project_alias/add"          : "\\Tracker\\Controller\\Issue\\Add",


### PR DESCRIPTION
Pull Request for Issue #885  .

### Summary of Changes
Some work on receiving the webhook for pull request reviews. I'm deliberately leaving doing the UI for this as a separate PR, so we can at least be storing the data whilst we are working on the interface

### TODO
1. Test it on a live service - I haven't figured out fully integrating this yet
2. I'm unsure if we get a hook on the COMMENT state documented in the API (https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review) or not
3. Do we want to save in the activities table who modified a review?
4. In the case of dismissing a comment from the docs alone I couldn't work out where the associated dismissed message was stored (if it is)
5. I wasn't sure whether the comments need to be stored as text rather than a `varchar(500)`
