### PR TITLE
Fix saving users on MySQL 5.7

### DIFF
--- a/src/JTracker/Authentication/Database/TableUsers.php
+++ b/src/JTracker/Authentication/Database/TableUsers.php
@@ -61,4 +61,24 @@ class TableUsers extends AbstractDatabaseTable
 
 		return ($check) ? $this->bind($check) : $this;
 	}
+
+	/**
+	 * Method to perform sanity checks on the AbstractDatabaseTable instance properties to ensure
+	 * they are safe to store in the database.  Child classes should override this
+	 * method to make sure the data they are storing in the database is safe and
+	 * as expected before storage.
+	 *
+	 * @return  $this  Method allows chaining
+	 *
+	 * @since   1.0
+	 */
+	public function check()
+	{
+		if ($this->params instanceof \Joomla\Registry\Registry)
+		{
+			$this->params = $this->params->toString();
+		}
+
+		return $this;
+	}
 }


### PR DESCRIPTION
```
1364 Joomla\Database\Exception\ExecutionFailureException
Field 'params' doesn't have a default value

exception: Joomla\Database\Exception\ExecutionFailureException: Field 'params' doesn't have a default value in ROOT/vendor/joomla/database/src/Mysqli/MysqliDriver.php:683
Stack trace:
#0 ROOT/vendor/joomla/database/src/DatabaseDriver.php(1046): Joomla\Database\Mysqli\MysqliDriver->execute()
#1 ROOT/src/JTracker/Database/AbstractDatabaseTable.php(418): Joomla\Database\DatabaseDriver->insertObject('#__users', Object(stdClass), 'id')
#2 ROOT/src/JTracker/Database/AbstractDatabaseTable.php(174): JTracker\Database\AbstractDatabaseTable->store()
#3 ROOT/src/JTracker/Authentication/User.php(169): JTracker\Database\AbstractDatabaseTable->save(Object(JTracker\Authentication\GitHub\GitHubUser))
#4 ROOT/src/App/Users/Controller/Login.php(122): JTracker\Authentication\User->loadByUserName('wilsonge')
#5 ROOT/src/JTracker/Application.php(174): App\Users\Controller\Login->execute()
#6 ROOT/vendor/joomla/application/src/AbstractWebApplication.php(186): JTracker\Application->doExecute()
#7 ROOT/www/index.php(106): Joomla\Application\AbstractWebApplication->execute()
#8 ROOT/www/index.php(133): {closure}()
#9 {main}
```

I guess someone should check this on the existing site with mysql 5.6 or whatever it's running