### PR TITLE
Fix using test hook

### DIFF
--- a/cli/Application/Command/Test/Hook.php
+++ b/cli/Application/Command/Test/Hook.php
@@ -149,7 +149,7 @@ class Hook extends Test
 		$this->controller = new $classname;
 		$this->controller->setContainer($this->getContainer());
 
-		if ($this->project->project_id === '1' && $resp === 3)
+		if ($this->project->project_id === 1 && $resp === 3)
 		{
 			$this->getApplication()->input->post->set('payload', file_get_contents(__DIR__ . '/data/cms-pull.json'));
 		}

--- a/src/App/Tracker/Controller/AbstractHookController.php
+++ b/src/App/Tracker/Controller/AbstractHookController.php
@@ -154,7 +154,7 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 		}
 
 		/* @type \JTracker\Application $application */
-		$application = $this->getContainer()->get('app');
+		$application = $this->getContainer()->get('JTracker\\Application');
 
 		$application->input->set('project_alias', $alias);
 
@@ -245,7 +245,7 @@ abstract class AbstractHookController extends AbstractAjaxController implements 
 			$myIP = $parts[0];
 		}
 		// Check if request is from CLI
-		elseif (strpos($_SERVER['SCRIPT_NAME'], 'cli/tracker.php') !== false)
+		elseif (strpos($_SERVER['SCRIPT_NAME'], 'cli/tracker.php') !== false || strpos($_SERVER['SCRIPT_NAME'], 'bin/jtracker') !== false)
 		{
 			$myIP = '127.0.0.1';
 		}

--- a/src/JTracker/Controller/AbstractTrackerController.php
+++ b/src/JTracker/Controller/AbstractTrackerController.php
@@ -303,7 +303,7 @@ abstract class AbstractTrackerController implements ContainerAwareInterface, Dis
 	protected function addEventListener($type)
 	{
 		/* @type \JTracker\Application $application */
-		$application = $this->getContainer()->get('app');
+		$application = $this->getContainer()->get('JTracker\\Application');
 
 		/*
 		 * Add the event listener if it exists.  Listeners are named in the format of <project><type>Listener in the Hooks\Listeners namespace.


### PR DESCRIPTION
Fixes a few issues when using the test hook functionality

1. Project ID is an integer not string
2. Running the cli from the bin folder isn't supported
3. We call `getProject` on the `app` property - however this is the cli application which doesn't have the function. In this case we need to explicitly get the WebApplication which contains that method (Would it be better to have an TrackerApplicationInterface which contains this method with a trait that has this method in both apps have available?)