### PR TITLE
Don't store dismissal info

### DIFF
--- a/src/App/Tracker/Controller/Hooks/ReceivePullReviewHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullReviewHook.php
@@ -250,12 +250,12 @@ class ReceivePullReviewHook extends AbstractHookController
 				// Prepare the dates for insertion to the database
 				$dateFormat = $this->db->getDateFormat();
 
-				// TODO: Where is the dismissed comment stored in the hook data??
+				// TODO: GitHub doesn't submit the person who authored the dismissal OR the comment associated with
+				//       the dismissal in the webhook. We'll have to try and access it another way. The intention is
+				//       to store these in the "dismissed_comment" and "dismissed_by" fields in the DB.
 				$data = [
-					'dismissed_by'      => $this->hookData->changes->body,
 					'dismissed_on'      => (new Date($this->hookData->pull_request->created_at))->format($dateFormat),
 					'review_state'      => ReviewsTable::DISMISSED_STATE
-					// 'dismissed_comment' => $this->hookData->changes->body,
 				];
 
 				$table->load(


### PR DESCRIPTION
GitHub hook doesn't give us the info we need. So just add a TODO for a rainy day