### PR TITLE
Create an issue if one doesn't exist

### DIFF
--- a/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
@@ -356,6 +356,8 @@ class ReceiveCommentsHook extends AbstractHookController
 				$table->id
 			)
 		);
+
+		return true;
 	}
 
 	/**

--- a/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceiveCommentsHook.php
@@ -246,6 +246,11 @@ class ReceiveCommentsHook extends AbstractHookController
 		$data['modified_by']     = $this->hookData->sender->login;
 		$data['project_id']      = $this->project->project_id;
 		$data['build']           = $this->hookData->repository->default_branch;
+		$data['pr_head_user']    = (isset($this->hookData->issue->head->user))
+			? $this->hookData->issue->head->user->login
+			: 'unknown_repository';
+		$data['pr_head_ref']     = $this->hookData->issue->head->ref;
+		$data['pr_head_sha']     = $this->hookData->issue->head->sha;
 
 		// Add the closed date if the status is closed
 		if ($this->hookData->issue->closed_at)

--- a/src/App/Tracker/Controller/Hooks/ReceivePullReviewHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullReviewHook.php
@@ -263,9 +263,11 @@ class ReceivePullReviewHook extends AbstractHookController
 				// Prepare the dates for insertion to the database
 				$dateFormat = $this->db->getDateFormat();
 
-				// TODO: GitHub doesn't submit the person who authored the dismissal OR the comment associated with
-				//       the dismissal in the webhook. We'll have to try and access it another way. The intention is
-				//       to store these in the "dismissed_comment" and "dismissed_by" fields in the DB.
+				/**
+				 * TODO: GitHub doesn't submit the person who authored the dismissal OR the comment associated with
+				 *       the dismissal in the webhook. We'll have to try and access it another way. The intention is
+				 *       to store these in the "dismissed_comment" and "dismissed_by" fields in the DB.
+				 */
 				$data = [
 					'dismissed_on'      => (new Date($this->hookData->pull_request->created_at))->format($dateFormat),
 					'review_state'      => ReviewsTable::DISMISSED_STATE


### PR DESCRIPTION
I can't test this because despite https://github.com/joomla/jissues/compare/fix/dismissed?expand=1#diff-7556531a1ad8f82503521b2e86695d92R363

I get

```
[2018-02-18 21:50:20] JTracker.ERROR: Database query failed (error #1364): Field 'labels' doesn't have a default value; Failed query: INSERT INTO `jos_issues` (`issue_number`,`project_id`,`title`,`description`,`description_raw`,`status`,`opened_date`,`opened_by`,`modified_date`,`modified_by`,`pr_head_user`,`pr_head_ref`,`pr_head_sha`,`build`) VALUES  ('19717','1','[4.0] Airbnb ECMAScript 2017 (ES6) Coding Standards for the files in directory build/build-modules-js','<body_text_removed_for_github>','1','2018-02-18 12:06:19','astridx','2018-02-18 21:05:39','dgt41','astridx','j4_airbnb/es6/codingstandards','a5e1ac26547c70cecdaecdbfbd7c9cb94542e2d8','staging') {"code":1364,"message":"Field 'labels' doesn't have a default value","sql":"INSERT INTO `jos_issues`\n(`issue_number`,`project_id`,`title`,`description`,`description_raw`,`status`,`opened_date`,`opened_by`,`modified_date`,`modified_by`,`pr_head_user`,`pr_head_ref`,`pr_head_sha`,`build`) VALUES \n('19717','1','[4.0] Airbnb ECMAScript 2017 (ES6) Coding Standards for the files in directory build/build-modules-js','<body_text_removed_for_github>','1','2018-02-18 12:06:19','astridx','2018-02-18 21:05:39','dgt41','astridx','j4_airbnb/es6/codingstandards','a5e1ac26547c70cecdaecdbfbd7c9cb94542e2d8','staging')"} []
```