### PR TITLE
GitHub allows more than one person to submit a review multiple times

### DIFF
--- a/src/App/Tracker/Controller/Hooks/ReceivePullReviewHook.php
+++ b/src/App/Tracker/Controller/Hooks/ReceivePullReviewHook.php
@@ -197,8 +197,7 @@ class ReceivePullReviewHook extends AbstractHookController
 		{
 			$table = (new ReviewsTable($this->db))->load(
 				[
-					'issue_id' => $this->hookData->pull_request->number,
-					'project_id' => $this->project->project_id,
+					'review_id' => $this->hookData->review->id,
 				]
 			);
 		}


### PR DESCRIPTION
Search by the Review Number because more than one person can submit a review, and you can review after each commit

I'm leaving the `issue_project_index` in place so we can use it for getting all reviews for an issue