### PR TITLE
Add the new components csp and workflow

### DIFF
--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -72,6 +72,8 @@ class JoomlacmsPullsListener extends AbstractListener
 	const CATEGORY_COM_FIELDS         = 71;
 	const CATEGORY_COM_ASSOCIATIONS   = 72;
 	const CATEGORY_COMPOSER           = 73;
+	const CATEGORY_COM_CSP            = 74;
+	const CATEGORY_COM_WORKFLOW       = 75;
 
 	/**
 	 * The Tracker Categories that are handled based on the files that changed by a pull request.
@@ -305,6 +307,13 @@ class JoomlacmsPullsListener extends AbstractListener
 			'^libraries/vendor',
 			'composer.json',
 			'composer.lock',
+		],
+		self::CATEGORY_COM_CSP => [
+			'^administrator/components/com_csp',
+			'^components/com_csp',
+		],
+		self::CATEGORY_COM_WORKFLOW => [
+			'^administrator/components/com_workflow',
 		],
 	];
 


### PR DESCRIPTION
Pull Request for Issue #1030 

#### Summary of Changes

Add the new components csp and workflow to the auto detection

Before this patch i have created the com_csp & com_workflow category in the tracker application. Do we need to include that somewhere in the repo too?

#### Testing Instructions

Create a patch that changes com_csp or com_workflow
The tracker now adds the categories