### PR TITLE
[Auto Labels] Make sure only NPM dependencies get tagged

### DIFF
--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -322,7 +322,7 @@ class JoomlacmsPullsListener extends AbstractListener
 			'administrator/components/com_media/package-lock.json',
 			'administrator/components/com_media/package.json',
 			'administrator/components/com_media/webpack.config.js',
-			'^build/media_source',
+			'^build/media_source/vendor',
 			'build.js',
 			'package-lock.json',
 			'package.json',


### PR DESCRIPTION
#### Summary of Changes

Make sure only external NPM dependencies get tagged as `NPM Dependency Changed`

#### Testing Instructions

- Please check: https://github.com/joomla/joomla-cms/pull/23936
- No NPM dependencies ins included in that patch.
- throw the PR against the current code and the proposed code.
