### PR TITLE
Change RFC label

### DIFF
--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsIssuesListener.php
@@ -114,7 +114,7 @@ class JoomlacmsIssuesListener extends AbstractListener
 	protected function checkIssueLabels($hookData, Github $github, Logger $logger, $project)
 	{
 		// Set some data
-		$rfcLabel     = 'Request for Comment';
+		$rfcLabel     = 'RFC';
 		$addLabels    = [];
 		$removeLabels = [];
 

--- a/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
+++ b/src/App/Tracker/Controller/Hooks/Listeners/JoomlacmsPullsListener.php
@@ -474,7 +474,7 @@ class JoomlacmsPullsListener extends AbstractListener
 	{
 		// Set some data
 		$prLabel              = 'PR-' . $hookData->pull_request->base->ref;
-		$rfcLabel             = 'Request for Comment';
+		$rfcLabel             = 'RFC';
 		$languageLabel        = 'Language Change';
 		$unitSystemTestsLabel = 'Unit/System Tests';
 		$composerLabel        = 'Composer Dependency Changed';


### PR DESCRIPTION
#### Summary of Changes
Change `Request for Comment` to `RFC` to consolidate redundant labels.
