### PR TITLE
Allow the jbs group to see and change the labels and milestones using the bot

### DIFF
--- a/src/App/Tracker/Controller/Issue/Save.php
+++ b/src/App/Tracker/Controller/Issue/Save.php
@@ -70,16 +70,12 @@ class Save extends AbstractTrackerController
 			// The user has full "edit" permission.
 			$data = $src;
 
-			// Allow admins to update labels and milestones
-			if (!$user->check('manage'))
+			if (!empty($item->labels))
 			{
-				if (!empty($item->labels))
-				{
-					$data['labels'] = explode(',', $item->labels);
-				}
-
-				$data['milestone_id'] = $item->milestone_id;
+				$data['labels'] = explode(',', $item->labels);
 			}
+
+			$data['milestone_id'] = $item->milestone_id;
 		}
 		elseif ($user->canEditOwn($item->opened_by))
 		{

--- a/templates/tracker/issue.add.twig
+++ b/templates/tracker/issue.add.twig
@@ -64,7 +64,7 @@
                     </div>
                 {% endif %}
 
-                {% if user.check('manage') %}
+                {% if user.check('edit') %}
 
                     {% if project.labels %}
                         {{ fields.label('labels', 'Labels') }}

--- a/templates/tracker/issue.edit.twig
+++ b/templates/tracker/issue.edit.twig
@@ -143,7 +143,7 @@
                 </li>
             {% endif %}
 
-            {% if user.check('manage') %}
+            {% if user.check('edit') %}
 
                 {% if project.labels %}
                     <li>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/25233

#### Summary of Changes

Allow the jbs group to see and change the labels and milestones using the bot

#### Testing Instructions

After this change the groups with edit permission can change the labels and milestones. Before only admins could have done that.