### PR TITLE
Update deprecated licence

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "laravel-mix": "^2.1.11"
     },
     "author": "Joomla!",
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "bugs": "https://github.com/joomla/jissues",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The spdx have deprecated the short license identifier GPL-2.0+ and we should use GPL-2.0-or-later
https://spdx.org/licenses/

Pull Request for Issue # .

#### Summary of Changes

#### Testing Instructions
