### PR TITLE
Fix accessibility issue: Add title attribute to Google Tag Manager iframe

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -43,7 +43,7 @@
 </head>
 <body class="site app-{{ app }} view-{{ view }} layout-{{ layout }}">
     <!-- Google Tag Manager -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M7HXQ7" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M7HXQ7" height="0" width="0" style="display:none;visibility:hidden" title="Google Tag Manager"></iframe></noscript>
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-M7HXQ7');</script>
     <!-- End Google Tag Manager -->
     {% block nav %}


### PR DESCRIPTION
Resolves issue #1310 - Accessibility error and alert joomla 5.4.2

## Problem
The Google Tag Manager iframe element in templates/index.twig was missing an accessible name (title or aria-label attribute), causing a WCAG accessibility compliance error:
'Embedded content requires an accessible name that describes its contents.'

## Solution
Added the 'title' attribute with value 'Google Tag Manager' to the iframe element.

## Changes
- Modified: templates/index.twig
- Added title attribute to iframe element on line 46

This fix ensures compliance with WCAG guidelines and resolves the accessibility error reported in issue #1310.